### PR TITLE
DM-22039: Rename dax_ppdb to dax_apdb (dax_ppdb)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,4 +1,4 @@
 # -*- python -*-
 from lsst.sconsUtils import scripts
 # Python-only package
-scripts.BasicSConstruct("dax_ppdb", disableCc=True)
+scripts.BasicSConstruct("dax_ppdb", disableCc=True, defaultTargets=["python", "doc", "version"])

--- a/python/lsst/dax/ppdb/__init__.py
+++ b/python/lsst/dax/ppdb/__init__.py
@@ -1,4 +1,6 @@
 
+raise ImportError("This package is being renamed to dax_apdb! Do not use!")
+
 from .ppdb import *
 from .ppdbSchema import *
 from .version import *


### PR DESCRIPTION
Add deprecation exception to `lsst.dax.ppdb`.

This package is deprecated and is being replaced by `dax_apdb`