### PR TITLE
Enable workflow dispatch in Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,5 +1,6 @@
 name: Docker
 on:
+  workflow_dispatch: {}
   pull_request: {}
   push:
     branches:

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql.py
@@ -35,6 +35,7 @@ import astropy.time
 import felis.datamodel
 import sqlalchemy
 import yaml
+from felis.datamodel import Schema as FelisSchema
 from lsst.dax.apdb import (
     ApdbMetadata,
     ApdbTableData,
@@ -229,7 +230,7 @@ class PpdbSql(Ppdb):
             table for table in schema_dict["tables"] if table["name"] not in ("DiaObjectLast",)
         ]
         schema_dict["tables"] = filtered_tables
-        dm_schema = felis.datamodel.Schema.model_validate(schema_dict)
+        dm_schema: FelisSchema = felis.datamodel.Schema.model_validate(schema_dict)
         schema = schema_model.Schema.from_felis(dm_schema)
 
         # Replace schema name with a configured one, just in case it may be


### PR DESCRIPTION
This PR enables workflow dispatch in the Docker workflow, as it sometimes needs to be manually triggered when dax_apdb changes. This would not automatically trigger a container rebuild, but the `main` image might need to be updated.