### PR TITLE
DM-49963: Fix PpdbSlq use of ApdbMetadata class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,10 @@ config.log
 version.py
 bin/
 
-# pip 
+# pip
 build/
 python/lsst_dax_ppdb.egg-info/
+python/lsst_dax_ppdb.dist-info/
 
 # Pytest
 tests/.tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,21 +8,21 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.11
+        language_version: python3.12
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.9
+    rev: v0.9.10
     hooks:
       - id: ruff


### PR DESCRIPTION
The `table_exists` method was removed, we should always assume
that metadata table exists.