### PR TITLE
DM-49202: Implement Parquet extractor and uploader for PPDB ETL pipeline

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -7,7 +7,6 @@ https://developer.lsst.io/stack/building-single-package-docs.html
 
 from documenteer.conf.pipelinespkg import *
 
-
 project = "dax_ppdb"
 html_theme_options["logotext"] = project
 html_title = project

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,10 +9,16 @@ disallow_incomplete_defs = True
 [mypy-astropy.*]
 ignore_missing_imports = True
 
+[mypy-google.*]
+ignore_missing_imports = True
+
 [mypy-lsst.daf.*]
 ignore_missing_imports = True
 
 [mypy-lsst.sphgeom]
+ignore_missing_imports = True
+
+[mypy-pyarrow.*]
 ignore_missing_imports = True
 
 [mypy-testing.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
     "pytest >= 3.2",
     "pytest-openfiles >= 0.5.0"
 ]
+gcs = ["google-cloud-storage"]
 
 [tool.setuptools.packages.find]
 where = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ classifiers = [
 keywords = ["lsst"]
 dependencies = [
     "astropy",
+    "google-auth",
+    "google-cloud-storage",
+    "google-cloud-pubsub",
     "pyyaml >= 5.1",
     "sqlalchemy",
     "lsst-felis",
@@ -39,12 +42,6 @@ dynamic = ["version"]
 test = [
     "pytest >= 3.2",
     "pytest-openfiles >= 0.5.0"
-]
-gcp = [
-    "google-auth",
-    "google-cloud-storage",
-    "google-cloud-bigquery",
-    "google-cloud-pubsub"
 ]
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "google-auth",
     "google-cloud-storage",
     "google-cloud-pubsub",
+    "pyarrow",
     "pyyaml >= 5.1",
     "sqlalchemy",
     "lsst-felis",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,12 @@ test = [
     "pytest >= 3.2",
     "pytest-openfiles >= 0.5.0"
 ]
-gcs = ["google-cloud-storage"]
+gcp = [
+    "google-auth",
+    "google-cloud-storage",
+    "google-cloud-bigquery",
+    "google-cloud-pubsub"
+]
 
 [tool.setuptools.packages.find]
 where = ["python"]

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -162,3 +162,9 @@ def upload_options(parser: argparse.ArgumentParser) -> None:
         default=False,
         action="store_true",
     )
+    group.add_argument(
+        "--exit-on-error",
+        help="Exit if an error occurs during upload.",
+        default=False,
+        action="store_true",
+    )

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -126,23 +126,21 @@ def export_options(parser: argparse.ArgumentParser) -> None:
     )
 
 
-"""
-def export_options(parser: argparse.ArgumentParser) -> None:
-    group = parser.add_argument_group("Google Cloud Storage options")
+def upload_options(parser: argparse.ArgumentParser) -> None:
+    """Define CLI options for Google Cloud Storage upload."""
+    group = parser.add_argument_group("Google Cloud Storage upload options")
+    group.add_argument("--directory", help="Directory to scan for chunk files.", default=None, required=True)
+    group.add_argument("--bucket", help="GCS bucket name.", default=None, required=True)
+    group.add_argument("--folder", help="GCS folder name.", default=None, required=True)
     group.add_argument(
-        "--bucket",
-        help="GCS bucket name.",
-        default=None,
+        "--wait-interval",
+        type=int,
+        help="Number of seconds to wait before scanning for more files.",
+        default=5,
     )
     group.add_argument(
-        "--folder",
-        help="GCS folder name.",
-        default=None,
+        "--exit-on-empty",
+        help="Exit if no files are found.",
+        default=False,
+        action="store_true",
     )
-    group.add_argument(
-        "--compression-format",
-        help="Compression format for Parquet files.",
-        default="snappy",
-        choices=["snappy", "gzip", "brotli", "zstd", "lz4", "none"],
-    )
-"""

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -141,19 +141,24 @@ def upload_options(parser: argparse.ArgumentParser) -> None:
     group.add_argument(
         "--wait-interval",
         type=int,
-        help="Number of seconds to wait before scanning for more files.",
+        help="Number of seconds to wait between file scans.",
         default=30,
     )
     group.add_argument(
         "--upload-interval",
         type=int,
-        help="Number of seconds to wait before uploading more files.",
+        help="Number of seconds to wait between uploading chunks.",
         default=0,
     )
-    group.add_argument
     group.add_argument(
         "--exit-on-empty",
-        help="Exit if no files are found.",
+        help="Exit if no new files are found after scanning.",
+        default=False,
+        action="store_true",
+    )
+    group.add_argument(
+        "--delete-chunks",
+        help="Delete chunks after they are successfully uploaded.",
         default=False,
         action="store_true",
     )

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -108,6 +108,12 @@ def replication_options(parser: argparse.ArgumentParser) -> None:
         metavar="SECONDS",
         help="Time to wait before next check if there was no replicated chunks, default: %(default)s.",
     )
+    group.add_argument(
+        "--exit-on-empty",
+        help="Exit if no chunks are found.",
+        default=False,
+        action="store_true",
+    )
 
 
 def export_options(parser: argparse.ArgumentParser) -> None:

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -137,7 +137,9 @@ def upload_options(parser: argparse.ArgumentParser) -> None:
     group = parser.add_argument_group("Google Cloud Storage upload options")
     group.add_argument("--directory", help="Directory to scan for chunk files.", default=None, required=True)
     group.add_argument("--bucket", help="GCS bucket name.", default=None, required=True)
-    group.add_argument("--folder", help="GCS folder name.", default=None, required=True)
+    group.add_argument(
+        "--prefix", help="GCS base prefix for the object, e.g., 'data/staging'.", default=None, required=True
+    )
     group.add_argument(
         "--wait-interval",
         type=int,

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -108,3 +108,41 @@ def replication_options(parser: argparse.ArgumentParser) -> None:
         metavar="SECONDS",
         help="Time to wait before next check if there was no replicated chunks, default: %(default)s.",
     )
+
+
+def export_options(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("chunk export options")
+    group.add_argument("--directory", help="Directory for local file storage.", required=True)
+    group.add_argument(
+        "--batch-size",
+        type=int,
+        help="Number of records to write in each batch.",
+    )
+    group.add_argument(
+        "--compression-format",
+        help="Compression format for Parquet files.",
+        default="snappy",
+        choices=["snappy", "gzip", "brotli", "zstd", "lz4", "none"],
+    )
+
+
+"""
+def export_options(parser: argparse.ArgumentParser) -> None:
+    group = parser.add_argument_group("Google Cloud Storage options")
+    group.add_argument(
+        "--bucket",
+        help="GCS bucket name.",
+        default=None,
+    )
+    group.add_argument(
+        "--folder",
+        help="GCS folder name.",
+        default=None,
+    )
+    group.add_argument(
+        "--compression-format",
+        help="Compression format for Parquet files.",
+        default="snappy",
+        choices=["snappy", "gzip", "brotli", "zstd", "lz4", "none"],
+    )
+"""

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -142,8 +142,15 @@ def upload_options(parser: argparse.ArgumentParser) -> None:
         "--wait-interval",
         type=int,
         help="Number of seconds to wait before scanning for more files.",
-        default=5,
+        default=30,
     )
+    group.add_argument(
+        "--upload-interval",
+        type=int,
+        help="Number of seconds to wait before uploading more files.",
+        default=0,
+    )
+    group.add_argument
     group.add_argument(
         "--exit-on-empty",
         help="Exit if no files are found.",

--- a/python/lsst/dax/ppdb/cli/ppdb_replication.py
+++ b/python/lsst/dax/ppdb/cli/ppdb_replication.py
@@ -52,6 +52,7 @@ def main() -> None:
     _list_chunks_apdb_subcommand(subparsers)
     _list_chunks_ppdb_subcommand(subparsers)
     _run_subcommand(subparsers)
+    _export_chunks_subcommand(subparsers)
 
     args = parser.parse_args()
     log_cli.process_args(args)
@@ -90,3 +91,12 @@ def _run_subcommand(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument("ppdb_config", help="Path to the PPDB configuration.")
     options.replication_options(parser)
     parser.set_defaults(method=scripts.replication_run)
+
+
+def _export_chunks_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("export-chunks", help="Export data from APDB to Parquet files.")
+    parser.add_argument("apdb_config", help="Path to the APDB configuration.")
+    parser.add_argument("ppdb_config", help="Path to the PPDB configuration.")
+    options.replication_options(parser)
+    options.export_options(parser)
+    parser.set_defaults(method=scripts.export_chunks_run)

--- a/python/lsst/dax/ppdb/cli/ppdb_replication.py
+++ b/python/lsst/dax/ppdb/cli/ppdb_replication.py
@@ -53,6 +53,7 @@ def main() -> None:
     _list_chunks_ppdb_subcommand(subparsers)
     _run_subcommand(subparsers)
     _export_chunks_subcommand(subparsers)
+    _upload_chunks_subcommand(subparsers)
 
     args = parser.parse_args()
     log_cli.process_args(args)
@@ -100,3 +101,9 @@ def _export_chunks_subcommand(subparsers: argparse._SubParsersAction) -> None:
     options.replication_options(parser)
     options.export_options(parser)
     parser.set_defaults(method=scripts.export_chunks_run)
+
+
+def _upload_chunks_subcommand(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser("upload-chunks", help="Upload data from Parquet files to GCS.")
+    options.upload_options(parser)
+    parser.set_defaults(method=scripts.upload_chunks_run)

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -92,7 +92,7 @@ class ChunkExporter(PpdbSql):
 
     @classmethod
     def _make_column_type_map(cls, metadata: sqlalchemy.MetaData) -> dict[str, dict[str, pyarrow.DataType]]:
-        """Create a mapping of column names to SQLAlchemy types."""
+        """Create a mapping of column names to Arrow types."""
         column_type_map = {}
         for table in metadata.tables.values():
             column_types = {}

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -171,10 +171,7 @@ class ChunkExporter(PpdbSql):
 
         # Prepare columns (columns, not rows)
         column_indices = {name: input_column_names.index(name) for name in selected_column_names}
-        selected_columns = [
-            [row[column_indices[name]] for row in rows]
-            for name in selected_column_names
-        ]
+        selected_columns = [[row[column_indices[name]] for row in rows] for name in selected_column_names]
 
         # Prepare schema
         schema = pyarrow.schema(

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import pprint
 from datetime import datetime
 from pathlib import Path
 
@@ -105,7 +104,6 @@ class ChunkExporter(PpdbSql):
                         )
                     column_types[column.name] = arrow_type
                 column_type_map[table.name] = column_types
-        _LOG.debug("Column type map:\n%s", pprint.pformat(column_type_map))
         return column_type_map
 
     def store(

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -124,9 +124,6 @@ class ChunkExporter(PpdbSql):
                 [objects, sources, forced_sources],
             ):
                 _LOG.info("Processing %s", table_name)
-                if len(table_data.rows()) == 0:
-                    _LOG.warning("Skipping %s for chunk %s: table is empty", table_name, replica_chunk.id)
-                    continue
                 try:
                     self._write_parquet(table_name, table_data, chunk_dir / f"{table_name}.parquet")
                 except Exception:

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -38,6 +38,8 @@ _LOG = logging.getLogger(__name__)
 
 _DEFAULT_COMPRESSION_FORMAT = "snappy"
 
+_DEFAULT_BATCH_SIZE = 1000
+
 _APDB_TABLES = ("DiaObject", "DiaSource", "DiaForcedSource")
 
 _SQLTYPE = sqlalchemy.sql.sqltypes
@@ -74,7 +76,7 @@ class ChunkExporter(PpdbSql):
         self,
         config: PpdbConfig,
         directory: Path,
-        batch_size: int = 1000,
+        batch_size: int = _DEFAULT_BATCH_SIZE,
         compression_format: str = _DEFAULT_COMPRESSION_FORMAT,
     ):
         super().__init__(config)
@@ -137,8 +139,7 @@ class ChunkExporter(PpdbSql):
                     arrow_table.num_rows,
                     arrow_table.num_columns,
                 )
-                memory_usage_mb = arrow_table.nbytes / 1_048_576
-                _LOG.debug("Estimated memory usage: %.2f MB", memory_usage_mb)
+                _LOG.debug("Estimated memory usage: %.2f MB", arrow_table.nbytes / 1_048_576)
 
                 file_path = chunk_dir / f"{table_name}.parquet"
                 parquet.write_table(arrow_table, file_path, compression=self.compression_format)

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -1,0 +1,195 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import pprint
+from datetime import datetime
+from pathlib import Path
+
+import pyarrow
+import sqlalchemy
+from lsst.dax.apdb import ApdbTableData, ReplicaChunk
+from pyarrow import parquet
+
+from ..config import PpdbConfig
+from ..sql._ppdb_sql import PpdbSql
+
+__all__ = ["ChunkExporter"]
+
+_LOG = logging.getLogger(__name__)
+
+_DEFAULT_COMPRESSION_FORMAT = "snappy"
+
+_APDB_TABLES = ("DiaObject", "DiaSource", "DiaForcedSource")
+
+_SQLTYPE = sqlalchemy.sql.sqltypes
+
+_PYARROW_TYPE = {
+    _SQLTYPE.BigInteger: pyarrow.int64(),
+    _SQLTYPE.Boolean: pyarrow.bool_(),
+    _SQLTYPE.CHAR: pyarrow.string(),
+    _SQLTYPE.Double: pyarrow.float64(),
+    _SQLTYPE.Integer: pyarrow.int32(),
+    _SQLTYPE.REAL: pyarrow.float64(),
+    _SQLTYPE.SmallInteger: pyarrow.int16(),
+    _SQLTYPE.TIMESTAMP: pyarrow.timestamp("ms", tz="UTC"),
+    _SQLTYPE.VARCHAR: pyarrow.string(),
+}
+
+
+class ChunkExporter(PpdbSql):
+    """Exports data from Cassandra to local Parquet files.
+
+    Parameters
+    ----------
+    config : `PpdbConfig`
+        Configuration object for PPDB.
+    directory : `Path`
+        Directory where the exported chunks will be stored.
+    batch_size : `int`, optional
+        Number of rows to process in each batch. Default is 1000.
+    compression_format : `str`, optional
+        Compression format for Parquet files. Default is "snappy".
+    """
+
+    def __init__(
+        self,
+        config: PpdbConfig,
+        directory: Path,
+        batch_size: int = 1000,
+        compression_format: str = _DEFAULT_COMPRESSION_FORMAT,
+    ):
+        super().__init__(config)
+        self.directory = directory
+        self.directory.mkdir(parents=True, exist_ok=True)
+        _LOG.info("Directory for chunk export: %s", self.directory)
+        self.batch_size = batch_size
+        self.compression_format = compression_format
+        self.schema_version = self._metadata.get(self.meta_schema_version_key)
+        self.column_type_map = self._make_column_type_map(self._sa_metadata)
+
+    @classmethod
+    def _make_column_type_map(cls, metadata: sqlalchemy.MetaData) -> dict[str, dict[str, pyarrow.DataType]]:
+        """Create a mapping of column names to SQLAlchemy types."""
+        column_type_map = {}
+        for table in metadata.tables.values():
+            column_types = {}
+            if table.name in _APDB_TABLES:
+                for column in table.columns.values():
+                    arrow_type = _PYARROW_TYPE.get(type(column.type), None)
+                    if arrow_type is None:
+                        raise ValueError(
+                            f'"{table.name}"."{column.name}" has an unsupported column type: {column.type}'
+                        )
+                    column_types[column.name] = arrow_type
+                column_type_map[table.name] = column_types
+        _LOG.debug("Column type map:\n%s", pprint.pformat(column_type_map))
+        return column_type_map
+
+    def store(
+        self,
+        replica_chunk: ReplicaChunk,
+        objects: ApdbTableData,
+        sources: ApdbTableData,
+        forced_sources: ApdbTableData,
+        *,
+        update: bool = False,
+    ) -> None:
+        # Docstring is inherited.
+        try:
+            chunk_dir = self._make_path(replica_chunk.id)
+            _LOG.debug("Temporary directory for chunk %s: %s", replica_chunk.id, chunk_dir)
+            for table_name, table_data in zip(
+                _APDB_TABLES,
+                [objects, sources, forced_sources],
+            ):
+                _LOG.info("Processing %s", table_name)
+                if len(table_data.rows()) == 0:
+                    _LOG.info("Skipping %s: table is empty", table_name)
+                    continue
+
+                try:
+                    arrow_table = self._convert_to_arrow(table_name, table_data)
+                except Exception as e:
+                    _LOG.error("Failed to convert table to Arrow: %s", e)
+                    raise
+
+                _LOG.info(
+                    "Created Arrow Table with %d rows and %d columns",
+                    arrow_table.num_rows,
+                    arrow_table.num_columns,
+                )
+                memory_usage_mb = arrow_table.nbytes / 1_048_576
+                _LOG.debug("Estimated memory usage: %.2f MB", memory_usage_mb)
+
+                file_path = chunk_dir / f"{table_name}.parquet"
+                parquet.write_table(arrow_table, file_path, compression=self.compression_format)
+
+        except Exception as e:
+            _LOG.error("Failed to store replica chunk: %s", e)
+            raise
+
+        # Mark the chunk as ready for upload by creating a ".ready" file.
+        self._set_ready(chunk_dir)
+
+        # Update the database to indicate that the chunk has been exported.
+        with self._engine.begin() as connection:
+            self._store_insert_id(replica_chunk, connection, update)
+
+    def _set_ready(self, directory: Path) -> None:
+        ready_file = directory / ".ready"
+        if not ready_file.exists():
+            ready_file.touch()
+            _LOG.info("Marked chunk %s as ready", directory)
+
+    def _make_path(self, chunk_id: int) -> Path:
+        path = Path(self.directory, datetime.today().strftime("%Y/%m/%d"), str(chunk_id))
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def _convert_to_arrow(self, table_name: str, table_data: ApdbTableData) -> pyarrow.Table:
+        expected_types = self.column_type_map.get(table_name)
+        if expected_types is None:
+            raise ValueError(f"No column type map found for table: {table_name}")
+
+        rows = list(table_data.rows())
+        input_column_names = list(table_data.column_names())
+
+        # Only keep columns present in the expected schema
+        selected_column_names = [name for name in input_column_names if name in expected_types]
+        if not selected_column_names:
+            raise ValueError(f"No matching columns found for table: {table_name}")
+
+        # Reorder and filter the columns to match selected_column_names
+        zipped_columns = list(zip(*rows))
+        selected_columns = [
+            col for name, col in zip(input_column_names, zipped_columns) if name in expected_types
+        ]
+
+        arrays = [
+            pyarrow.array(column, type=expected_types[column_name])
+            for column, column_name in zip(selected_columns, selected_column_names)
+        ]
+        schema = pyarrow.schema(
+            [(column_name, expected_types[column_name]) for column_name in selected_column_names]
+        )
+
+        return pyarrow.table(arrays, schema=schema)

--- a/python/lsst/dax/ppdb/export/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/export/_chunk_exporter.py
@@ -66,6 +66,8 @@ class ChunkExporter(PpdbSql):
         Configuration object for PPDB.
     directory : `Path`
         Directory where the exported chunks will be stored.
+    schema_version : `VersionTuple`
+        Version of the APDB schema to use for the export.
     batch_size : `int`, optional
         Number of rows to process in each batch. Default is 1000.
     compression_format : `str`, optional
@@ -119,10 +121,12 @@ class ChunkExporter(PpdbSql):
         try:
             chunk_dir = self._make_path(replica_chunk.id)
             _LOG.debug("Created directory for chunk %s: %s", replica_chunk.id, chunk_dir)
-            for table_name, table_data in zip(
-                _APDB_TABLES,
-                [objects, sources, forced_sources],
-            ):
+            table_dict = {
+                "DiaObject": objects,
+                "DiaSource": sources,
+                "DiaForcedSource": forced_sources,
+            }
+            for table_name, table_data in table_dict.items():
                 _LOG.info("Processing %s", table_name)
                 try:
                     self._write_parquet(table_name, table_data, chunk_dir / f"{table_name}.parquet")

--- a/python/lsst/dax/ppdb/export/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/export/_chunk_uploader.py
@@ -219,6 +219,9 @@ class ChunkUploader:
             if self.delete_chunks:
                 self._delete_chunk(chunk_dir)
 
+            # Delete the ".ready" marker file
+            (chunk_dir / ".ready").unlink()
+
             # Mark the chunk as uploaded
             self._mark_uploaded(chunk_dir)
 

--- a/python/lsst/dax/ppdb/export/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/export/_chunk_uploader.py
@@ -77,7 +77,8 @@ class ChunkUploader:
         exit_on_empty: bool = False,
         delete_chunks: bool = False,
         exit_on_error: bool = False,
-    ):
+        topic_name: str = _PUBSUB_TOPIC_NAME,
+    ) -> None:
         self.bucket_name = bucket_name
         self.prefix = prefix
         self.directory = directory
@@ -105,7 +106,7 @@ class ChunkUploader:
         self.client = storage.Client()
         self.bucket = self.client.bucket(self.bucket_name)
 
-        self.topic_name = _PUBSUB_TOPIC_NAME
+        self.topic_name = topic_name
 
     def run(self) -> None:
         """Start the uploader to scan for files and upload them."""

--- a/python/lsst/dax/ppdb/export/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/export/_chunk_uploader.py
@@ -43,7 +43,7 @@ _PUBSUB_TOPIC_NAME = "stage-chunk-topic"
 
 class ChunkUploader:
     """Scans a local directory tree for chunks that are ready to be uploaded
-    and copies their parquet files to the specified GCS bucket and folder.
+    and copies their parquet files to the specified GCS bucket and prefix.
 
     Parameters
     ----------
@@ -51,8 +51,8 @@ class ChunkUploader:
         The local directory to scan for parquet files.
     bucket_name : `str`
         The name of the GCS bucket for uploads.
-    folder_name : `str`
-        The folder name in the GCS bucket for uploads.
+    prefix : `str`
+        The base prefix for the uploaded objects, e.g., 'data/staging'.
     wait_interval : `int`
         The time in seconds to wait between scans of the local directory.
     upload_interval : `int`
@@ -71,7 +71,7 @@ class ChunkUploader:
         self,
         directory: str,
         bucket_name: str,
-        folder_name: str,
+        prefix: str,
         wait_interval: int = 30,
         upload_interval: int = 0,
         exit_on_empty: bool = False,
@@ -79,7 +79,7 @@ class ChunkUploader:
         exit_on_error: bool = False,
     ):
         self.bucket_name = bucket_name
-        self.folder_name = folder_name
+        self.prefix = prefix
         self.directory = directory
         self.wait_interval = wait_interval
         self.upload_interval = upload_interval
@@ -200,7 +200,7 @@ class ChunkUploader:
         try:
             # Get the GCS names for the parquet files
             relative_chunk_path = Path(chunk_dir).relative_to(self.directory)
-            gcs_prefix = posixpath.join(self.folder_name, str(relative_chunk_path))
+            gcs_prefix = posixpath.join(self.prefix, str(relative_chunk_path))
             gcs_names = {file: posixpath.join(gcs_prefix, file.name) for file in parquet_files}
 
             # Upload parquet files to GCS

--- a/python/lsst/dax/ppdb/export/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/export/_chunk_uploader.py
@@ -143,9 +143,8 @@ class ChunkUploader:
             _LOG.exception("Failed to upload %s", file_path)
             raise
 
-    def _set_ready(self, chunk_dir: Path) -> None:
-        relative_chunk_path = Path(chunk_dir).relative_to(self.directory)
-        ready_file_path = posixpath.join(self.folder_name, str(relative_chunk_path), ".ready")
+    def _set_ready(self, gcs_path: Path) -> None:
+        ready_file_path = posixpath.join(gcs_path, ".ready")
         blob = self.bucket.blob(ready_file_path)
         try:
             blob.upload_from_string("")

--- a/python/lsst/dax/ppdb/export/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/export/_chunk_uploader.py
@@ -1,0 +1,149 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import os
+import posixpath
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from google.cloud import storage
+
+__all__ = ["ChunkUploader"]
+
+_LOG = logging.getLogger(__name__)
+
+
+class ChunkUploader:
+    """Scans a local directory tree for parquet files that are ready to be
+    uploaded to Google Cloud Storage (GCS).
+
+    Parameters
+    ----------
+    directory : `str`
+        The local directory to scan for parquet files.
+    bucket_name : `str`
+        The name of the GCS bucket to upload files to.
+    folder_name : `str`
+        The folder name in the GCS bucket where files will be uploaded.
+    wait_interval : `int`
+        The time in seconds to wait between scans of the local directory.
+    """
+
+    def __init__(
+        self,
+        directory: str,
+        bucket_name: str,
+        folder_name: str,
+        wait_interval: int,
+        exit_on_empty: bool,
+    ):
+        self.bucket_name = bucket_name
+        self.folder_name = folder_name
+        self.directory = directory
+        self.wait_interval = wait_interval
+        self.exit_on_empty = exit_on_empty
+
+        # Environment check
+        if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+            raise RuntimeError("Environment variable GOOGLE_APPLICATION_CREDENTIALS is not set.")
+        credentials_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if not credentials_path or not os.path.exists(credentials_path):
+            raise RuntimeError("Invalid GOOGLE_APPLICATION_CREDENTIALS path.")
+
+        self.client = storage.Client()
+        self.bucket = self.client.bucket(self.bucket_name)
+
+    def run(self):
+        while True:
+            _LOG.info("Checking for new chunks to upload...")
+
+            ready_files = list(Path(self.directory).rglob(".ready"))
+            if ready_files:
+                _LOG.info("Found %d ready files", len(ready_files))
+                for ready_file in ready_files:
+                    self._process_chunk(ready_file)
+                    ready_file.unlink()
+            else:
+                _LOG.info("No ready files found.")
+                if self.exit_on_empty:
+                    _LOG.info("Exiting as no files were found.")
+                    break
+
+            _LOG.info("Sleeping for %d seconds", self.wait_interval)
+            time.sleep(self.wait_interval)
+
+    def _process_chunk(self, ready_file: Path):
+        chunk_dir = ready_file.parent
+        parquet_files = list(chunk_dir.glob("*.parquet"))
+
+        if not parquet_files:
+            _LOG.warning("No parquet files in %s", chunk_dir)
+            return
+
+        relative_chunk_path = Path(chunk_dir).relative_to(self.directory)
+        base_gcs_path = posixpath.join(self.folder_name, str(relative_chunk_path))
+        gcs_paths = {file: posixpath.join(base_gcs_path, file.name) for file in parquet_files}
+        try:
+            self._upload_files(gcs_paths)
+            self._set_ready(base_gcs_path)
+        except Exception as e:
+            _LOG.error("Upload failed: %s", e)
+            self._delete_objects(gcs_paths.values())
+            self._set_failed(chunk_dir)
+
+    def _upload_files(self, gcs_paths: dict[str, str]) -> None:
+        with ThreadPoolExecutor() as executor:
+            executor.map(self._upload_single_file, gcs_paths.items())
+
+    def _upload_single_file(self, file_path_gcs_tuple):
+        file_path, gcs_path = file_path_gcs_tuple
+        blob = self.bucket.blob(gcs_path)
+        try:
+            blob.upload_from_filename(file_path)
+            _LOG.info("Uploaded %s to %s", file_path, gcs_path)
+        except Exception as e:
+            _LOG.error("Failed to upload %s: %s", file_path, e)
+            raise
+
+    def _set_ready(self, chunk_dir: Path) -> None:
+        ready_file_path = f"{chunk_dir}/.ready"
+        blob = self.bucket.blob(ready_file_path)
+        try:
+            blob.upload_from_string("")
+            _LOG.info("Created .ready file at GCS path: %s", ready_file_path)
+        except Exception as e:
+            _LOG.error("Failed to create .ready file: %s", e)
+            raise
+
+    def _set_failed(self, chunk_dir: Path) -> None:
+        (chunk_dir / ".failed").touch()
+        _LOG.info("Marked chunk %s upload as failed", chunk_dir)
+
+    def _delete_objects(self, gcs_paths: list[str]) -> None:
+        for gcs_path in gcs_paths:
+            blob = self.bucket.blob(gcs_path)
+            try:
+                blob.delete()
+                _LOG.info("Deleted GCS path %s", gcs_path)
+            except Exception as e:
+                _LOG.error("Failed to delete %s: %s", gcs_path, e)

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -179,7 +179,7 @@ class Replicator:
         with Timer("store_chunks_time", _MON):
             self._ppdb.store(replica_chunk, dia_objects, dia_sources, dia_forced_sources, update=self._update)
 
-    def run(self, single=False, exit_on_empty=False) -> None:
+    def run(self, single: bool = False, exit_on_empty: bool = False) -> None:
         """Run the replication loop.
 
         Parameters

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 __all__ = ["Replicator"]
 
 import logging
+import time
+import warnings
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
@@ -41,7 +43,7 @@ _MON = monitor.MonAgent(__name__)
 
 
 class Replicator:
-    """Implementation of APDB-to-PPDB replication metods.
+    """Implementation of APDB-to-PPDB replication methods.
 
     Parameters
     ----------
@@ -59,6 +61,8 @@ class Replicator:
     max_wait_time : `int`
         Maximum time in seconds to wait for replicating a chunk if no chunk
         appears.
+    check_interval : `int`
+        Time in seconds to wait before checking for new chunks.
     """
 
     def __init__(
@@ -68,12 +72,14 @@ class Replicator:
         update: bool,
         min_wait_time: int,
         max_wait_time: int,
+        check_interval: int,
     ):
         self._apdb = apdb
         self._ppdb = ppdb
         self._update = update
         self._min_wait_time = min_wait_time
         self._max_wait_time = max_wait_time
+        self._check_interval = check_interval
 
     def copy_chunks(
         self,
@@ -172,3 +178,55 @@ class Replicator:
 
         with Timer("store_chunks_time", _MON):
             self._ppdb.store(replica_chunk, dia_objects, dia_sources, dia_forced_sources, update=self._update)
+
+    def run(self, single=False) -> None:
+        """Run the replication loop.
+
+        Parameters
+        ----------
+        single : `bool`, optional
+            If `True` then copy only one chunk and stop. Default is `False`.
+        """
+        wait_time = 0
+        while True:
+            if wait_time > 0:
+                _LOG.info("Waiting %s seconds before next iteration.", wait_time)
+                time.sleep(wait_time)
+
+            # Get existing chunks in APDB.
+            apdb_chunks = self._apdb.getReplicaChunks()
+            if apdb_chunks is None:
+                raise TypeError("APDB implementation does not support replication")
+            min_chunk_id = min((chunk.id for chunk in apdb_chunks), default=None)
+            if min_chunk_id is None:
+                # No chunks in APDB?
+                _LOG.info("No replica chunks found in APDB.")
+                if single:
+                    return
+                else:
+                    wait_time = self._check_interval
+                    continue
+
+            # Get existing chunks in PPDB.
+            ppdb_chunks = self._ppdb.get_replica_chunks(min_chunk_id)
+            if ppdb_chunks is None:
+                raise TypeError("PPDB implementation does not support replication")
+
+            # Check existing PPDB ids for consistency.
+            ppdb_id_map = {ppdb_chunk.id: ppdb_chunk for ppdb_chunk in ppdb_chunks}
+            for apdb_chunk in apdb_chunks:
+                if (ppdb_chunk := ppdb_id_map.get(apdb_chunk.id)) is not None:
+                    if ppdb_chunk.unique_id != apdb_chunk.unique_id:
+                        # Crash if running in a single-shot mode.
+                        message = f"Inconsistent values of unique ID - APDB: {apdb_chunk} PPDB: {ppdb_chunk}"
+                        if single:
+                            raise ValueError(message)
+                        else:
+                            warnings.warn(message)
+
+            # Replicate one or many chunks.
+            chunks = self.copy_chunks(apdb_chunks, ppdb_chunks, 1 if single else None)
+            if single:
+                break
+            # IF something was copied then start new iteration immediately.
+            wait_time = 0 if chunks else self._check_interval

--- a/python/lsst/dax/ppdb/scripts/__init__.py
+++ b/python/lsst/dax/ppdb/scripts/__init__.py
@@ -23,3 +23,4 @@ from .create_sql import create_sql
 from .replication_list_chunks_apdb import replication_list_chunks_apdb
 from .replication_list_chunks_ppdb import replication_list_chunks_ppdb
 from .replication_run import replication_run
+from .export_chunks_run import export_chunks_run

--- a/python/lsst/dax/ppdb/scripts/__init__.py
+++ b/python/lsst/dax/ppdb/scripts/__init__.py
@@ -20,8 +20,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from .create_sql import create_sql
+from .export_chunks_run import export_chunks_run
 from .replication_list_chunks_apdb import replication_list_chunks_apdb
 from .replication_list_chunks_ppdb import replication_list_chunks_ppdb
 from .replication_run import replication_run
-from .export_chunks_run import export_chunks_run
 from .upload_chunks_run import upload_chunks_run

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -80,7 +80,7 @@ def export_chunks_run(
 
     ppdb = ChunkExporter(
         ppdb_sql_config,
-        apdb._schema.schemaVersion(),  # type: ignore[attr-defined]
+        apdb.schemaVersion(),
         Path(directory),
         batch_size=batch_size,
         compression_format=compression_format,

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 __all__ = ["export_chunks_run"]
 
-import logging
 from pathlib import Path
 
 from lsst.dax.apdb import ApdbReplica
@@ -31,8 +30,6 @@ from lsst.dax.apdb import ApdbReplica
 from ..export._chunk_exporter import ChunkExporter
 from ..replicator import Replicator
 from ..sql._ppdb_sql import PpdbSqlConfig
-
-_LOG = logging.getLogger(__name__)
 
 
 def export_chunks_run(
@@ -79,10 +76,14 @@ def export_chunks_run(
         Exit if no chunks are found.
     """
     apdb = ApdbReplica.from_uri(apdb_config)
-    _ppdb_config = PpdbSqlConfig.from_uri(ppdb_config)
+    ppdb_sql_config = PpdbSqlConfig.from_uri(ppdb_config)
 
     ppdb = ChunkExporter(
-        _ppdb_config, Path(directory), batch_size=batch_size, compression_format=compression_format
+        ppdb_sql_config,
+        apdb._schema.schemaVersion(),  # type: ignore[attr-defined]
+        Path(directory),
+        batch_size=batch_size,
+        compression_format=compression_format,
     )
 
     replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time, check_interval)

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -1,0 +1,127 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["export_chunks_run"]
+
+import logging
+import time
+import warnings
+
+from pathlib import Path
+
+from lsst.dax.apdb import ApdbReplica
+
+from ..export._chunk_exporter import ChunkExporter
+from ..sql._ppdb_sql import PpdbSqlConfig
+
+from ..replicator import Replicator
+
+_LOG = logging.getLogger(__name__)
+
+
+def export_chunks_run(
+    apdb_config: str,
+    ppdb_config: str,
+    single: bool,
+    update: bool,
+    min_wait_time: int,
+    max_wait_time: int,
+    check_interval: int,
+    directory: str,
+    compression_format: str,
+    batch_size: int,
+) -> None:
+    """Execute replication process from APDB to PPDB.
+
+    Parameters
+    ----------
+    apdb_config : `str`
+        URL for APDB configuration file.
+    ppdb_config : `str`
+        URL for PPDB configuration file.
+    single : `bool`
+        Copy single bucket and stop.
+    update : `bool`
+        If `True` then allow updates to previously replicated data.
+    min_wait_time : `int`
+        Minimum time in seconds to wait for replicating a chunk after a next
+        chunk appears.
+    max_wait_time : `int`
+        Maximum time in seconds to wait for replicating a chunk if no chunk
+        appears.
+    check_interval : `int`
+        Time in seconds to wait before next check if there was no replicated
+        chunks.
+    """
+    apdb = ApdbReplica.from_uri(apdb_config)
+
+    _ppdb_config = PpdbSqlConfig.from_uri(ppdb_config)
+    ppdb = ChunkExporter(
+        _ppdb_config, Path(directory), batch_size=batch_size, compression_format=compression_format
+    )
+
+    replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time)
+
+    wait_time = 0
+    while True:
+        if wait_time > 0:
+            _LOG.info("Waiting %s seconds before next iteration.", wait_time)
+            time.sleep(wait_time)
+
+        # Get existing chunks in APDB.
+        apdb_chunks = apdb.getReplicaChunks()
+        if apdb_chunks is None:
+            raise TypeError("APDB implementation does not support replication")
+        min_chunk_id = min((chunk.id for chunk in apdb_chunks), default=None)
+        if min_chunk_id is None:
+            # No chunks in APDB?
+            _LOG.info("No replica chunks found in APDB.")
+            if single:
+                return
+            else:
+                wait_time = check_interval
+                continue
+
+        # Get existing chunks in PPDB.
+        ppdb_chunks = ppdb.get_replica_chunks(min_chunk_id)
+        if ppdb_chunks is None:
+            raise TypeError("PPDB implementation does not support replication")
+
+        # Check existing PPDB ids for consistency.
+        ppdb_id_map = {ppdb_chunk.id: ppdb_chunk for ppdb_chunk in ppdb_chunks}
+        for apdb_chunk in apdb_chunks:
+            if (ppdb_chunk := ppdb_id_map.get(apdb_chunk.id)) is not None:
+                if ppdb_chunk.unique_id != apdb_chunk.unique_id:
+                    # Crash if running in a single-shot mode.
+                    message = f"Inconsistent values of unique ID - APDB: {apdb_chunk} PPDB: {ppdb_chunk}"
+                    if single:
+                        raise ValueError(message)
+                    else:
+                        warnings.warn(message)
+
+        # Replicate one or many chunks.
+        chunks = replicator.copy_chunks(apdb_chunks, ppdb_chunks, 1 if single else None)
+        if single:
+            break
+        # IF something was copied then start new iteration immediately.
+        wait_time = 0 if chunks else check_interval

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -43,6 +43,7 @@ def export_chunks_run(
     min_wait_time: int,
     max_wait_time: int,
     check_interval: int,
+    exit_on_empty: bool,
     directory: str,
     compression_format: str,
     batch_size: int,
@@ -68,6 +69,14 @@ def export_chunks_run(
     check_interval : `int`
         Time in seconds to wait before next check if there was no replicated
         chunks.
+    directory : `str`
+        Directory where the chunks are stored.
+    compression_format : `str`
+        Compression format for the chunks.
+    batch_size : `int`
+        Number of records to write in each batch for the Parquet files.
+    exit_on_empty : `bool`
+        Exit if no chunks are found.
     """
     apdb = ApdbReplica.from_uri(apdb_config)
     _ppdb_config = PpdbSqlConfig.from_uri(ppdb_config)
@@ -77,4 +86,4 @@ def export_chunks_run(
     )
 
     replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time, check_interval)
-    replicator.run(single)
+    replicator.run(single=single, exit_on_empty=exit_on_empty)

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -26,15 +26,13 @@ __all__ = ["export_chunks_run"]
 import logging
 import time
 import warnings
-
 from pathlib import Path
 
 from lsst.dax.apdb import ApdbReplica
 
 from ..export._chunk_exporter import ChunkExporter
-from ..sql._ppdb_sql import PpdbSqlConfig
-
 from ..replicator import Replicator
+from ..sql._ppdb_sql import PpdbSqlConfig
 
 _LOG = logging.getLogger(__name__)
 

--- a/python/lsst/dax/ppdb/scripts/export_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/export_chunks_run.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 __all__ = ["export_chunks_run"]
 
 import logging
-import time
-import warnings
 from pathlib import Path
 
 from lsst.dax.apdb import ApdbReplica
@@ -72,54 +70,11 @@ def export_chunks_run(
         chunks.
     """
     apdb = ApdbReplica.from_uri(apdb_config)
-
     _ppdb_config = PpdbSqlConfig.from_uri(ppdb_config)
+
     ppdb = ChunkExporter(
         _ppdb_config, Path(directory), batch_size=batch_size, compression_format=compression_format
     )
 
-    replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time)
-
-    wait_time = 0
-    while True:
-        if wait_time > 0:
-            _LOG.info("Waiting %s seconds before next iteration.", wait_time)
-            time.sleep(wait_time)
-
-        # Get existing chunks in APDB.
-        apdb_chunks = apdb.getReplicaChunks()
-        if apdb_chunks is None:
-            raise TypeError("APDB implementation does not support replication")
-        min_chunk_id = min((chunk.id for chunk in apdb_chunks), default=None)
-        if min_chunk_id is None:
-            # No chunks in APDB?
-            _LOG.info("No replica chunks found in APDB.")
-            if single:
-                return
-            else:
-                wait_time = check_interval
-                continue
-
-        # Get existing chunks in PPDB.
-        ppdb_chunks = ppdb.get_replica_chunks(min_chunk_id)
-        if ppdb_chunks is None:
-            raise TypeError("PPDB implementation does not support replication")
-
-        # Check existing PPDB ids for consistency.
-        ppdb_id_map = {ppdb_chunk.id: ppdb_chunk for ppdb_chunk in ppdb_chunks}
-        for apdb_chunk in apdb_chunks:
-            if (ppdb_chunk := ppdb_id_map.get(apdb_chunk.id)) is not None:
-                if ppdb_chunk.unique_id != apdb_chunk.unique_id:
-                    # Crash if running in a single-shot mode.
-                    message = f"Inconsistent values of unique ID - APDB: {apdb_chunk} PPDB: {ppdb_chunk}"
-                    if single:
-                        raise ValueError(message)
-                    else:
-                        warnings.warn(message)
-
-        # Replicate one or many chunks.
-        chunks = replicator.copy_chunks(apdb_chunks, ppdb_chunks, 1 if single else None)
-        if single:
-            break
-        # IF something was copied then start new iteration immediately.
-        wait_time = 0 if chunks else check_interval
+    replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time, check_interval)
+    replicator.run(single)

--- a/python/lsst/dax/ppdb/scripts/replication_run.py
+++ b/python/lsst/dax/ppdb/scripts/replication_run.py
@@ -41,6 +41,7 @@ def replication_run(
     min_wait_time: int,
     max_wait_time: int,
     check_interval: int,
+    exit_on_empty: bool,
 ) -> None:
     """Execute replication process from APDB to PPDB.
 
@@ -68,4 +69,4 @@ def replication_run(
     ppdb = Ppdb.from_uri(ppdb_config)
 
     replicator = Replicator(apdb, ppdb, update, min_wait_time, max_wait_time, check_interval)
-    replicator.run(single)
+    replicator.run(single=single, exit_on_empty=exit_on_empty)

--- a/python/lsst/dax/ppdb/scripts/replication_run.py
+++ b/python/lsst/dax/ppdb/scripts/replication_run.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 __all__ = ["replication_run"]
 
 import logging
-import time
-import warnings
 
 from lsst.dax.apdb import ApdbReplica
 

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -23,7 +23,13 @@ from ..export._chunk_uploader import ChunkUploader
 
 
 def upload_chunks_run(
-    directory: str, bucket: str, folder: str, wait_interval: int, upload_interval: int, exit_on_empty: bool
+    directory: str,
+    bucket: str,
+    folder: str,
+    wait_interval: int,
+    upload_interval: int,
+    exit_on_empty: bool,
+    delete_chunks: bool,
 ) -> None:
     """Upload chunks to the specified bucket and folder.
 
@@ -37,5 +43,7 @@ def upload_chunks_run(
         Name of the folder within the bucket to upload the chunks to. If not
         provided, the chunks will be uploaded to the root of the bucket.
     """
-    chunk_exporter = ChunkUploader(directory, bucket, folder, wait_interval, upload_interval, exit_on_empty)
+    chunk_exporter = ChunkUploader(
+        directory, bucket, folder, wait_interval, upload_interval, exit_on_empty, delete_chunks
+    )
     chunk_exporter.run()

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -25,14 +25,14 @@ from ..export._chunk_uploader import ChunkUploader
 def upload_chunks_run(
     directory: str,
     bucket: str,
-    folder: str,
+    prefix: str,
     wait_interval: int,
     upload_interval: int,
     exit_on_empty: bool,
     delete_chunks: bool,
     exit_on_error: bool,
 ) -> None:
-    """Upload chunks to the specified bucket and folder.
+    """Upload chunks to the specified bucket and prefix.
 
     Parameters
     ----------
@@ -40,9 +40,8 @@ def upload_chunks_run(
         Directory containing the chunks to upload.
     bucket : `str`
         Name of the bucket to upload the chunks to.
-    folder : `str`, optional
-        Name of the folder within the bucket to upload the chunks to. If not
-        provided, the chunks will be uploaded to the root of the bucket.
+    prefix : `str`, optional
+        Prefix within the bucket for object naming.
     wait_interval : `int`
         Time in seconds to wait before checking for new chunks to upload.
     upload_interval : `int`
@@ -53,6 +52,6 @@ def upload_chunks_run(
         If `True`, delete the chunks after they have been uploaded.
     """
     chunk_exporter = ChunkUploader(
-        directory, bucket, folder, wait_interval, upload_interval, exit_on_empty, delete_chunks, exit_on_error
+        directory, bucket, prefix, wait_interval, upload_interval, exit_on_empty, delete_chunks, exit_on_error
     )
     chunk_exporter.run()

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -23,7 +23,7 @@ from ..export._chunk_uploader import ChunkUploader
 
 
 def upload_chunks_run(
-    directory: str, bucket: str, folder: str, wait_interval: int, exit_on_empty: bool
+    directory: str, bucket: str, folder: str, wait_interval: int, upload_interval: int, exit_on_empty: bool
 ) -> None:
     """Upload chunks to the specified bucket and folder.
 
@@ -37,5 +37,5 @@ def upload_chunks_run(
         Name of the folder within the bucket to upload the chunks to. If not
         provided, the chunks will be uploaded to the root of the bucket.
     """
-    chunk_exporter = ChunkUploader(directory, bucket, folder, wait_interval, exit_on_empty)
+    chunk_exporter = ChunkUploader(directory, bucket, folder, wait_interval, upload_interval, exit_on_empty)
     chunk_exporter.run()

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -22,7 +22,9 @@
 from ..export._chunk_uploader import ChunkUploader
 
 
-def upload_chunks_run(directory: str, bucket: str, folder: str, wait_interval: int, exit_on_empty: bool):
+def upload_chunks_run(
+    directory: str, bucket: str, folder: str, wait_interval: int, exit_on_empty: bool
+) -> None:
     """Upload chunks to the specified bucket and folder.
 
     Parameters

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -37,11 +37,19 @@ def upload_chunks_run(
     ----------
     directory : `str`
         Directory containing the chunks to upload.
-    bucket_name : `str`
+    bucket : `str`
         Name of the bucket to upload the chunks to.
-    folder_name : `str`, optional
+    folder : `str`, optional
         Name of the folder within the bucket to upload the chunks to. If not
         provided, the chunks will be uploaded to the root of the bucket.
+    wait_interval : `int`
+        Time in seconds to wait before checking for new chunks to upload.
+    upload_interval : `int`
+        Time in seconds to wait between uploads of chunks.
+    exit_on_empty : `bool`
+        If `True`, exit the process if there are no chunks to upload.
+    delete_chunks : `bool`
+        If `True`, delete the chunks after they have been uploaded.
     """
     chunk_exporter = ChunkUploader(
         directory, bucket, folder, wait_interval, upload_interval, exit_on_empty, delete_chunks

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -19,9 +19,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .create_sql import create_sql
-from .replication_list_chunks_apdb import replication_list_chunks_apdb
-from .replication_list_chunks_ppdb import replication_list_chunks_ppdb
-from .replication_run import replication_run
-from .export_chunks_run import export_chunks_run
-from .upload_chunks_run import upload_chunks_run
+from ..export._chunk_uploader import ChunkUploader
+
+
+def upload_chunks_run(directory: str, bucket: str, folder: str, wait_interval: int, exit_on_empty: bool):
+    """Upload chunks to the specified bucket and folder.
+
+    Parameters
+    ----------
+    directory : `str`
+        Directory containing the chunks to upload.
+    bucket_name : `str`
+        Name of the bucket to upload the chunks to.
+    folder_name : `str`, optional
+        Name of the folder within the bucket to upload the chunks to. If not
+        provided, the chunks will be uploaded to the root of the bucket.
+    """
+    chunk_exporter = ChunkUploader(directory, bucket, folder, wait_interval, exit_on_empty)
+    chunk_exporter.run()

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -30,6 +30,7 @@ def upload_chunks_run(
     upload_interval: int,
     exit_on_empty: bool,
     delete_chunks: bool,
+    exit_on_error: bool,
 ) -> None:
     """Upload chunks to the specified bucket and folder.
 
@@ -52,6 +53,6 @@ def upload_chunks_run(
         If `True`, delete the chunks after they have been uploaded.
     """
     chunk_exporter = ChunkUploader(
-        directory, bucket, folder, wait_interval, upload_interval, exit_on_empty, delete_chunks
+        directory, bucket, folder, wait_interval, upload_interval, exit_on_empty, delete_chunks, exit_on_error
     )
     chunk_exporter.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 astropy
+google-auth
+google-cloud-storage
+google-cloud-pubsub
 pyyaml >= 5.1
 sqlalchemy
 lsst-dax-apdb @ git+https://github.com/lsst/dax_apdb@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astropy
 google-auth
 google-cloud-storage
 google-cloud-pubsub
+pyarrow
 pyyaml >= 5.1
 sqlalchemy
 lsst-dax-apdb @ git+https://github.com/lsst/dax_apdb@main

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W503, E203
 exclude =
   bin,
   doc/conf.py,


### PR DESCRIPTION
This PR implements several modules for the PPDB ETL pipeline into BigQuery. An exporter writes parquet files from the Cassandra-based APDB implementation into a local directory tree and can be run with `ppdb-replication export-chunks`. The uploader then copies these parquet files into Google Cloud Storage (GCS) along with a manifest file (JSON) and publishes an event to a Pub/Sub topic to trigger a cloud function. The uploader can be run with `ppdb-replication upload-chunks`.

In future, it is planned to replace the usage of local marker files in these utilities with a replica chunk database used for bookkeeping of the ETL pipeline.

**TODO**

- [x] In the Beam job script, get the parameters from the manifest file instead of inferring them from the GCS object name
- [x] Add options to the uploader for specifying a wait time between chunk uploads, to avoid possibly overloading BigQuery with updates, as well as the time to wait between scanning for chunks that are ready (similar to the existing `ppdb-replication run` command). These settings could also be used to reduce load on the APDB, should this be necessary.
- [x] Find a better way to get schema version than `apdb._schema.schemaVersion()` (should this be exposed in the `ApdbReplica` interface in `dax_apdb`?)