### PR TITLE
DM-52173: Refactor and reorganize classes in the `bigquery` module related to SQL and replica chunk management

### DIFF
--- a/python/lsst/dax/ppdb/_factory.py
+++ b/python/lsst/dax/ppdb/_factory.py
@@ -27,10 +27,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .config import PpdbConfig
-    from .sql import PpdbSql
+    from .ppdb import Ppdb
 
 
-def ppdb_type(config: PpdbConfig) -> type[PpdbSql]:
+def ppdb_type(config: PpdbConfig) -> type[Ppdb]:
     """Return Ppdb class matching Ppdb configuration type.
 
     Parameters
@@ -63,7 +63,7 @@ def ppdb_type(config: PpdbConfig) -> type[PpdbSql]:
     raise TypeError(f"Unknown type of config object: {type(config)}")
 
 
-def ppdb_type_for_name(type_name: str) -> type[PpdbSql]:
+def ppdb_type_for_name(type_name: str) -> type[Ppdb]:
     """Return Ppdb class matching type name.
 
     Parameters

--- a/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
@@ -70,6 +70,8 @@ class ChunkExporter(Ppdb):
             raise TypeError(f"Expecting PpdbBigQueryConfig instance but got {type(config)}")
 
         # Initialize the SQL interface.
+        if config.sql is None:
+            raise ValueError("SQL configuration is not set in configuration.")
         self._sql = PpdbReplicaChunkSql(config.sql)
         self._metadata = self._sql.metadata  # APDB metadata object (not SQA)
         self._schema_version = self._sql.schema_version  # Database schema version

--- a/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
@@ -70,7 +70,7 @@ class ChunkExporter(Ppdb):
             raise TypeError(f"Expecting PpdbBigQueryConfig instance but got {type(config)}")
 
         # Initialize the SQL interface.
-        self._sql = PpdbReplicaChunkSql(config)
+        self._sql = PpdbReplicaChunkSql(config.sql)
         self._metadata = self._sql.metadata  # APDB metadata object (not SQA)
         self._schema_version = self._sql.schema_version  # Database schema version
 

--- a/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_exporter.py
@@ -21,6 +21,7 @@
 
 import logging
 import shutil
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -90,7 +91,7 @@ class ChunkExporter(Ppdb):
         # docstring is inherited from a base class
         return self._metadata
 
-    def get_replica_chunks(self, start_chunk_id: int | None = None) -> list[PpdbReplicaChunk] | None:
+    def get_replica_chunks(self, start_chunk_id: int | None = None) -> Sequence[PpdbReplicaChunk] | None:
         # docstring is inherited from a base class
         return self._sql.get_replica_chunks(start_chunk_id)
 

--- a/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
@@ -103,6 +103,8 @@ class ChunkUploader:
         self.config = config
 
         # Setup SQL interface for accessing replica chunk data.
+        if config.sql is None:
+            raise ValueError("SQL configuration is not set in configuration.")
         self._sql = PpdbReplicaChunkSql(config.sql)
 
         # Read parameters from config

--- a/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
@@ -103,7 +103,7 @@ class ChunkUploader:
         self.config = config
 
         # Setup SQL interface for accessing replica chunk data.
-        self._sql = PpdbReplicaChunkSql(config)
+        self._sql = PpdbReplicaChunkSql(config.sql)
 
         # Read parameters from config
         if self.config.prefix is None:

--- a/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
@@ -143,7 +143,7 @@ class ChunkUploader:
             try:
                 # Get replica chunks that have been exported and are ready for
                 # upload to cloud storage.
-                replica_chunks = self._sql.get_replica_chunks_by_status(status=ChunkStatus.EXPORTED)
+                replica_chunks = self._sql.get_replica_chunks_ext(status=ChunkStatus.EXPORTED)
             except Exception:
                 # Some problem occurred while retrieving replica chunk data.
                 # Log the error and continue to the next iteration or exit if

--- a/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/_chunk_uploader.py
@@ -255,10 +255,7 @@ class ChunkUploader:
 
             # 3) Update DB status.
             try:
-                with self._sql._engine.begin() as connection:
-                    self._sql.store_chunk(
-                        replica_chunk.with_new_status(ChunkStatus.UPLOADED), connection, True
-                    )
+                self._sql.store_chunk(replica_chunk.with_new_status(ChunkStatus.UPLOADED), True)
             except Exception as e:
                 raise ChunkUploadError(chunk_id, "failed to update replica chunk status in database") from e
 

--- a/python/lsst/dax/ppdb/bigquery/_config.py
+++ b/python/lsst/dax/ppdb/bigquery/_config.py
@@ -21,23 +21,34 @@
 
 from pathlib import Path
 
-from ..sql._ppdb_sql import PpdbSqlConfig
+from ..sql.ppdb_sql_config import PpdbSqlConfig
 
 
-# DM-52173: Due to the class structure of ChunkExporter, the config needs to
-# inherit from PpdbSqlConfig. This should be refactored in the future so that
-# it is standalone.
 class PpdbBigQueryConfig(PpdbSqlConfig):
-    """Configuration for BigQuery-based PPDB."""
+    """Configuration for BigQuery-based PPDB.
+
+    Notes
+    -----
+    This class inherits from `PpdbSqlConfig`, as it needs to share the database
+    connection parameters, typically for a Postgres instance, which is required
+    by both the 'sql' and 'bigquery' implementations of the PPDB. Various SQL
+    utilities expect a `PpdbSqlConfig` instance, so this is the easiest way to
+    type it for now without changing them.
+
+    This class uses the new `PpdbSqlConfig` from `ppdb_sql_config`, which is
+    intended to be public, instead of the one from `_ppdb_sql`. That module
+    may be removed sometime in the future so we don't want to depend on it.
+    """
 
     apdb_schema_uri: str = "resource://lsst.sdm.schemas/apdb.yaml"
-    """URI of the APDB schema definition."""
+    """URI of the APDB schema definition (`str`)."""
 
     replica_chunk_table: str = "PpdbReplicaChunk"
-    """Name of the table used to track replica chunks."""
+    """Name of the table used to track replica chunks (`str`)."""
 
     directory: Path | None = None
-    """Directory where the exported chunks will be stored."""
+    """Directory where the exported chunks will be stored
+    (`Path` or `None`)."""
 
     delete_existing: bool = False
     """If `True`, existing directories for chunks will be deleted before
@@ -45,20 +56,22 @@ class PpdbBigQueryConfig(PpdbSqlConfig):
     exists."""
 
     stage_chunk_topic: str = "stage-chunk-topic"
-    """Pub/Sub topic name for triggering chunk staging process."""
+    """Pub/Sub topic name for triggering chunk staging process (`str`)."""
 
     batch_size: int = 1000
-    """Number of rows to process in each batch when writing parquet files."""
+    """Number of rows to process in each batch when writing parquet files
+    (`int`, defaults to 1000)."""
 
     compression_format: str = "snappy"
-    """Compression format for Parquet files."""
+    """Compression format for Parquet files (`str`, defaults to "snappy")."""
 
     bucket: str | None = None
-    """Name of Google Cloud Storage bucket for uploading chunks."""
+    """Name of Google Cloud Storage bucket for uploading chunks (`str`)."""
 
     prefix: str | None = None
-    """Base prefix for the object in cloud storage."""
+    """Base prefix for the object in cloud storage (`str`)."""
 
     dataset: str | None = None
-    """Target BigQuery dataset, e.g., 'my_project:my_dataset'. If not provided
-    the project will be derived from the environment."""
+    """Target BigQuery dataset, e.g., 'my_project:my_dataset'
+    (`str` or `None`). If not provided the project will be derived from the
+    Google Cloud environment at runtime."""

--- a/python/lsst/dax/ppdb/bigquery/_config.py
+++ b/python/lsst/dax/ppdb/bigquery/_config.py
@@ -30,6 +30,12 @@ from ..sql._ppdb_sql import PpdbSqlConfig
 class PpdbBigQueryConfig(PpdbSqlConfig):
     """Configuration for BigQuery-based PPDB."""
 
+    apdb_schema_uri: str = "resource://lsst.sdm.schemas/apdb.yaml"
+    """URI of the APDB schema definition."""
+
+    replica_chunk_table: str = "PpdbReplicaChunk"
+    """Name of the table used to track replica chunks."""
+
     directory: Path | None = None
     """Directory where the exported chunks will be stored."""
 

--- a/python/lsst/dax/ppdb/bigquery/_config.py
+++ b/python/lsst/dax/ppdb/bigquery/_config.py
@@ -21,30 +21,16 @@
 
 from pathlib import Path
 
+from ..ppdb import PpdbConfig
 from ..sql.ppdb_sql_config import PpdbSqlConfig
 
 
-class PpdbBigQueryConfig(PpdbSqlConfig):
+class PpdbBigQueryConfig(PpdbConfig):
     """Configuration for BigQuery-based PPDB.
 
-    Notes
-    -----
-    This class inherits from `PpdbSqlConfig`, as it needs to share the database
-    connection parameters, typically for a Postgres instance, which is required
-    by both the 'sql' and 'bigquery' implementations of the PPDB. Various SQL
-    utilities expect a `PpdbSqlConfig` instance, so this is the easiest way to
-    type it for now without changing them.
-
-    This class uses the new `PpdbSqlConfig` from `ppdb_sql_config`, which is
-    intended to be public, instead of the one from `_ppdb_sql`. That module
-    may be removed sometime in the future so we don't want to depend on it.
+    This also includes configuration for the SQL database used to track
+    replica chunks under the `sql` attribute.
     """
-
-    apdb_schema_uri: str = "resource://lsst.sdm.schemas/apdb.yaml"
-    """URI of the APDB schema definition (`str`)."""
-
-    replica_chunk_table: str = "PpdbReplicaChunk"
-    """Name of the table used to track replica chunks (`str`)."""
 
     directory: Path | None = None
     """Directory where the exported chunks will be stored
@@ -75,3 +61,6 @@ class PpdbBigQueryConfig(PpdbSqlConfig):
     """Target BigQuery dataset, e.g., 'my_project:my_dataset'
     (`str` or `None`). If not provided the project will be derived from the
     Google Cloud environment at runtime."""
+
+    sql: PpdbSqlConfig | None = None
+    """SQL database configuration (`SqlConfig` or `None`)."""

--- a/python/lsst/dax/ppdb/cli/ppdb_cli.py
+++ b/python/lsst/dax/ppdb/cli/ppdb_cli.py
@@ -64,10 +64,7 @@ def _create_bigquery_replica_chunk_sql_subcommand(subparsers: argparse._SubParse
     parser = subparsers.add_parser(
         "create-bq-replica-chunk-sql", help="Create database for tracking replica chunks in BigQuery."
     )
-    parser.add_argument("db_url", help="Database URL in SQLAlchemy format.")
-    parser.add_argument("output_config", help="Name of the new BigQuery PPDB configuration file.")
-    options.felis_schema_options(parser)
-    options.sql_db_options(parser)
+    parser.add_argument("ppdb_config", help="Path to the PPDB configuration.")
     parser.add_argument(
         "--drop", help="If True then drop existing tables.", default=False, action="store_true"
     )

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -56,7 +56,8 @@ class Ppdb(ABC):
 
         Notes
         -----
-        This is a no-op to satisfy typing in the ``from_config`` class method.
+        This is a no-op initializer to satisfy typing in the ``from_config``
+        class method. Child classes do not need to call this.
         """
         pass
 
@@ -105,8 +106,6 @@ class Ppdb(ABC):
         """
         raise NotImplementedError()
 
-    # TODO: Change return type to Sequence so that we can support variadic
-    # types
     @abstractmethod
     def get_replica_chunks(self, start_chunk_id: int | None = None) -> list[PpdbReplicaChunk] | None:
         """Return collection of replica chunks known to the database.

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -27,7 +27,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import astropy.time
-
 from lsst.dax.apdb import ApdbMetadata, ApdbTableData, ReplicaChunk
 from lsst.resources import ResourcePathExpression
 
@@ -44,7 +43,22 @@ class PpdbReplicaChunk(ReplicaChunk):
 
 
 class Ppdb(ABC):
-    """Class defining an interface for PPDB management operations."""
+    """Class defining an interface for PPDB management operations.
+
+    Parameters
+    ----------
+    config : `PpdbConfig`
+        Configuration object used to initialize the implementation.
+    """
+
+    def __init__(self, config: PpdbConfig) -> None:
+        """Initialize the Ppdb instance.
+
+        Notes
+        -----
+        This is a no-op to satisfy typing in the ``from_config`` class method.
+        """
+        pass
 
     @classmethod
     def from_config(cls, config: PpdbConfig) -> Ppdb:
@@ -62,7 +76,6 @@ class Ppdb(ABC):
             Instance of `Ppdb` class.
         """
         # Dispatch to actual implementation class based on config type.
-
         ppdb_class = ppdb_type(config)
         return ppdb_class(config)
 

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 __all__ = ["Ppdb"]
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import astropy.time
@@ -107,7 +108,7 @@ class Ppdb(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_replica_chunks(self, start_chunk_id: int | None = None) -> list[PpdbReplicaChunk] | None:
+    def get_replica_chunks(self, start_chunk_id: int | None = None) -> Sequence[PpdbReplicaChunk] | None:
         """Return collection of replica chunks known to the database.
 
         Parameters

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -27,6 +27,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import astropy.time
+
 from lsst.dax.apdb import ApdbMetadata, ApdbTableData, ReplicaChunk
 from lsst.resources import ResourcePathExpression
 
@@ -91,6 +92,8 @@ class Ppdb(ABC):
         """
         raise NotImplementedError()
 
+    # TODO: Change return type to Sequence so that we can support variadic
+    # types
     @abstractmethod
     def get_replica_chunks(self, start_chunk_id: int | None = None) -> list[PpdbReplicaChunk] | None:
         """Return collection of replica chunks known to the database.

--- a/python/lsst/dax/ppdb/scripts/create_bigquery_replica_chunk_sql.py
+++ b/python/lsst/dax/ppdb/scripts/create_bigquery_replica_chunk_sql.py
@@ -42,7 +42,10 @@ def create_bigquery_replica_chunk_sql(
     drop : `bool`
         If `True` then drop existing tables.
     """
-    config = PpdbConfig.from_uri(ppdb_config)
-    if not isinstance(config, PpdbBigQueryConfig):
+    bq_config = PpdbConfig.from_uri(ppdb_config)
+    if not isinstance(bq_config, PpdbBigQueryConfig):
         raise ValueError(f"PPDB configuration must be of type 'bigquery': {ppdb_config}")
-    PpdbReplicaChunkSql.init_database(config, drop=drop)
+    sql_config = bq_config.sql
+    if sql_config is None:
+        raise ValueError("SQL configuration is not provided in the PPDB configuration")
+    PpdbReplicaChunkSql.init_database(sql_config, drop=drop)

--- a/python/lsst/dax/ppdb/scripts/create_bigquery_replica_chunk_sql.py
+++ b/python/lsst/dax/ppdb/scripts/create_bigquery_replica_chunk_sql.py
@@ -25,7 +25,7 @@ __all__ = ["create_bigquery_replica_chunk_sql"]
 
 import yaml
 
-from ..bigquery._replica_chunk import PpdbReplicaChunkSql
+from ..sql._ppdb_sql import PpdbSql
 
 
 def create_bigquery_replica_chunk_sql(
@@ -67,7 +67,7 @@ def create_bigquery_replica_chunk_sql(
     # the tables needed for tracking BigQuery replica chunks, including the
     # PpdbReplicaChunk and metadata tables. Currently, it includes the entire
     # PPDB Postgres representation plus some extra columns.
-    config = PpdbReplicaChunkSql.init_database(
+    config = PpdbSql.init_database(
         db_url=db_url,
         schema_name=schema,
         schema_file=felis_path,

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
@@ -33,15 +33,11 @@ class PpdbSqlConfig(PpdbConfig):
     schema_name: str | None = None
     """Database schema name, if `None` then default schema is used."""
 
-    felis_path: str | None = None
-    """Name of YAML file with ``felis`` schema, if `None` then default schema
-    file is used.
-    """
+    apdb_schema_uri: str = "resource://lsst.sdm.schemas/apdb.yaml"
+    """URI of the APDB schema definition (`str`)."""
 
-    felis_schema: str | None = None
-    """Name of the schema in YAML file, if `None` then file has to contain
-    single schema.
-    """
+    replica_chunk_table: str = "PpdbReplicaChunk"
+    """Name of the table used to track replica chunks (`str`)."""
 
     use_connection_pool: bool = True
     """If True then allow use of connection pool."""

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
@@ -21,28 +21,35 @@
 
 from __future__ import annotations
 
-__all__ = ["create_bigquery_replica_chunk_sql"]
-
-from ..bigquery._config import PpdbBigQueryConfig
-from ..bigquery._replica_chunk import PpdbReplicaChunkSql
 from ..ppdb import PpdbConfig
 
 
-def create_bigquery_replica_chunk_sql(
-    ppdb_config: str,
-    drop: bool,
-) -> None:
-    """Create new SQL database for tracking replica chunks.
+class PpdbSqlConfig(PpdbConfig):
+    """Configuration for the `PpdbSql` class."""
 
-    Parameters
-    ----------
-    ppdb_config : `str`
-        Path to the PPDB configuration which must be of type
-        `PpdbBigQueryConfig`.
-    drop : `bool`
-        If `True` then drop existing tables.
+    db_url: str
+    """SQLAlchemy database connection URI."""
+
+    schema_name: str | None = None
+    """Database schema name, if `None` then default schema is used."""
+
+    felis_path: str | None = None
+    """Name of YAML file with ``felis`` schema, if `None` then default schema
+    file is used.
     """
-    config = PpdbConfig.from_uri(ppdb_config)
-    if not isinstance(config, PpdbBigQueryConfig):
-        raise ValueError(f"PPDB configuration must be of type 'bigquery': {ppdb_config}")
-    PpdbReplicaChunkSql.init_database(config, drop=drop)
+
+    felis_schema: str | None = None
+    """Name of the schema in YAML file, if `None` then file has to contain
+    single schema.
+    """
+
+    use_connection_pool: bool = True
+    """If True then allow use of connection pool."""
+
+    isolation_level: str | None = None
+    """Transaction isolation level, if unset then backend-default value is
+    used.
+    """
+
+    connection_timeout: float | None = None
+    """Maximum connection timeout in seconds."""

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
@@ -25,7 +25,7 @@ from ..ppdb import PpdbConfig
 
 
 class PpdbSqlConfig(PpdbConfig):
-    """Configuration for the `PpdbSql` class."""
+    """Configuration of SQL database parameters."""
 
     db_url: str
     """SQLAlchemy database connection URI."""

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_config.py
@@ -49,3 +49,7 @@ class PpdbSqlConfig(PpdbConfig):
 
     connection_timeout: float | None = None
     """Maximum connection timeout in seconds."""
+
+    max_row_buffer: int = 1000
+    """Maximum number of rows to buffer in memory when streaming query
+    results."""

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
@@ -1,0 +1,245 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("PpdbSqlUtils",)
+
+import logging
+import sqlite3
+from collections.abc import MutableMapping
+from contextlib import closing
+from typing import Any
+
+import felis
+import sqlalchemy
+from lsst.dax.apdb import (
+    VersionTuple,
+    schema_model,
+)
+from lsst.dax.apdb.sql import ApdbMetadataSql
+from sqlalchemy.pool import NullPool
+
+from .ppdb_sql_config import PpdbSqlConfig
+
+_LOG = logging.getLogger(__name__)
+
+
+def _onSqlite3Connect(
+    dbapiConnection: sqlite3.Connection, connectionRecord: sqlalchemy.pool._ConnectionRecord
+) -> None:
+    # Enable foreign keys
+    with closing(dbapiConnection.cursor()) as cursor:
+        cursor.execute("PRAGMA foreign_keys=ON;")
+
+
+class PpdbSqlUtils:
+    """Miscellaneous, standalone utility functions for PPDB SQL operations.
+
+    Notes
+    -----
+    These utilities were extracted from the `PpdbSql` class to avoid
+    dependencies on it. That class was not modified to use these functions to
+    avoid changing its behavior.
+    """
+
+    meta_schema_version_key = "version:schema"
+    """Name of the metadata key to store schema version number."""
+
+    @classmethod
+    def make_engine(cls, config: PpdbSqlConfig) -> sqlalchemy.engine.Engine:
+        """Make SQLALchemy engine based on configured parameters.
+
+        Parameters
+        ----------
+        config : `PpdbSqlConfig`
+            Configuration object.
+        """
+        kw: MutableMapping[str, Any] = {}
+        conn_args: dict[str, Any] = dict()
+        if not config.use_connection_pool:
+            kw["poolclass"] = NullPool
+        if config.isolation_level is not None:
+            kw.update(isolation_level=config.isolation_level)
+        elif config.db_url.startswith("sqlite"):
+            # Use READ_UNCOMMITTED as default value for sqlite.
+            kw.update(isolation_level="READ_UNCOMMITTED")
+        if config.connection_timeout is not None:
+            if config.db_url.startswith("sqlite"):
+                conn_args.update(timeout=config.connection_timeout)
+            elif config.db_url.startswith(("postgresql", "mysql")):
+                conn_args.update(connect_timeout=config.connection_timeout)
+        kw = {"connect_args": conn_args}
+        engine = sqlalchemy.create_engine(config.db_url, **kw)
+
+        if engine.dialect.name == "sqlite":
+            # Need to enable foreign keys on every new connection.
+            sqlalchemy.event.listen(engine, "connect", _onSqlite3Connect)
+
+        return engine
+
+    @classmethod
+    def make_database(
+        cls,
+        config: PpdbSqlConfig,
+        sa_metadata: sqlalchemy.schema.MetaData,
+        schema_version: VersionTuple | None,
+        drop: bool,
+    ) -> None:
+        """Initialize database schema.
+
+        Parameters
+        ----------
+        db_url : `str`
+            SQLAlchemy database connection URI.
+        schema_name : `str` or `None`
+            Database schema name, if `None` then default schema is used.
+        sa_metadata : `sqlalchemy.schema.MetaData`
+            Schema definition.
+        schema_version : `lsst.dax.apdb.VersionTuple` or `None`
+            Schema version defined in schema or `None` if not defined.
+        drop : `bool`
+            If `True` then drop existing tables before creating new ones.
+        """
+        engine = cls.make_engine(config)
+
+        if config.schema_name is not None:
+            dialect = engine.dialect
+            quoted_schema = dialect.preparer(dialect).quote_schema(config.schema_name)
+            create_schema = sqlalchemy.DDL(
+                "CREATE SCHEMA IF NOT EXISTS %(schema)s", context={"schema": quoted_schema}
+            ).execute_if(dialect="postgresql")
+            sqlalchemy.event.listen(sa_metadata, "before_create", create_schema)
+
+        if drop:
+            _LOG.info("dropping all tables")
+            sa_metadata.drop_all(engine)
+        _LOG.info("creating all tables")
+        sa_metadata.create_all(engine)
+
+        # TODO: Code below here dealing with APDB metadata should probably go
+        # into a separate function.
+
+        # Need metadata table to store few items in it, if table exists.
+        meta_table: sqlalchemy.schema.Table
+        for table in sa_metadata.tables.values():
+            if table.name == "metadata":
+                meta_table = table
+                break
+        else:
+            raise LookupError("Metadata table does not exist.")
+
+        apdb_meta = ApdbMetadataSql(engine, meta_table)
+        # Fill schema version number and overwrite if present.
+        if schema_version is not None:
+            _LOG.info("Store metadata %s = %s", cls.meta_schema_version_key, schema_version)
+            apdb_meta.set(cls.meta_schema_version_key, str(schema_version), force=True)
+        # We don't fill the code version number here as it seems to be
+        # unnecessary and would need to be passed in by the caller. It can be
+        # added later if needed.
+
+    @classmethod
+    def make_replica_chunk_table(cls, table_name: str | None = None) -> schema_model.Table:
+        """Create the default ``PpdbReplicaChunk`` table in its APDB
+        `schema_model` representation.
+
+        Parameters
+        ----------
+        table_name : `str` or `None`
+            Name of the table to create. If not provided, defaults to
+            "PpdbReplicaChunk".
+        """
+        table_name = table_name or "PpdbReplicaChunk"
+        columns = [
+            schema_model.Column(
+                name="apdb_replica_chunk",
+                id=f"#{table_name}.apdb_replica_chunk",
+                datatype=felis.datamodel.DataType.long,
+            ),
+            schema_model.Column(
+                name="last_update_time",
+                id=f"#{table_name}.last_update_time",
+                datatype=felis.datamodel.DataType.timestamp,
+                nullable=False,
+            ),
+            schema_model.Column(
+                name="unique_id",
+                id=f"#{table_name}.unique_id",
+                datatype=schema_model.ExtraDataTypes.UUID,
+                nullable=False,
+            ),
+            schema_model.Column(
+                name="replica_time",
+                id=f"#{table_name}.replica_time",
+                datatype=felis.datamodel.DataType.timestamp,
+                nullable=False,
+            ),
+        ]
+        indices = [
+            schema_model.Index(
+                name="PpdbInsertId_idx_last_update_time",
+                id="#PpdbInsertId_idx_last_update_time",
+                columns=[columns[1]],
+            ),
+            schema_model.Index(
+                name="PpdbInsertId_idx_replica_time",
+                id="#PpdbInsertId_idx_replica_time",
+                columns=[columns[3]],
+            ),
+        ]
+
+        # Add table for replication support.
+        chunks_table = schema_model.Table(
+            name=table_name,
+            id=f"#{table_name}",
+            columns=columns,
+            primary_key=[columns[0]],
+            indexes=indices,
+            constraints=[],
+        )
+        return chunks_table
+
+    @classmethod
+    def get_table(cls, sa_metadata: sqlalchemy.schema.MetaData, name: str) -> sqlalchemy.schema.Table:
+        """Get table from SQLAlchemy metadata by name, without including the
+        schema name.
+
+        Parameters
+        ----------
+        sa_metadata : `sqlalchemy.schema.MetaData`
+            Schema definition.
+        name : `str`
+            Name of the table to get.
+
+        Returns
+        -------
+        table : `sqlalchemy.schema.Table`
+            Table object.
+
+        Raises
+        ------
+        LookupError
+            If table with given name does not exist.
+        """
+        for table in sa_metadata.tables.values():
+            if table.name == name:
+                return table
+        raise LookupError(f"Unknown table {name}")

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
@@ -107,7 +107,6 @@ class PpdbSqlUtils:
         sa_metadata: sqlalchemy.schema.MetaData,
         schema_version: VersionTuple | None,
         drop: bool,
-        include_tables: list[str] | None = None,
     ) -> None:
         """Initialize database schema.
 
@@ -140,7 +139,7 @@ class PpdbSqlUtils:
         _LOG.info("creating all tables")
         sa_metadata.create_all(engine)
 
-        # Need metadata table to store few items in it, if table exists.
+        # Find the metadata table to use for storing schema version.
         meta_table = cls.find_table_by_name(sa_metadata, cls.metadata_table_name)
 
         apdb_meta = ApdbMetadataSql(engine, meta_table)

--- a/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
+++ b/python/lsst/dax/ppdb/sql/ppdb_sql_utils.py
@@ -162,6 +162,9 @@ class PpdbSqlUtils:
         """Create the default ``PpdbReplicaChunk`` table in its APDB
         `schema_model` representation.
 
+        This includes fields for the chunk's status and the directory
+        containing its exported data, both declared as nullable.
+
         Parameters
         ----------
         table_name : `str` or `None`
@@ -192,6 +195,18 @@ class PpdbSqlUtils:
                 id=f"#{table_name}.replica_time",
                 datatype=felis.datamodel.DataType.timestamp,
                 nullable=False,
+            ),
+            schema_model.Column(
+                name="status",
+                id=f"#{table_name}.status",
+                datatype=felis.datamodel.DataType.string,
+                nullable=True,
+            ),
+            schema_model.Column(
+                name="directory",
+                id=f"#{table_name}.directory",
+                datatype=felis.datamodel.DataType.string,
+                nullable=True,
             ),
         ]
         indices = [

--- a/python/lsst/dax/ppdb/tests/_ppdb.py
+++ b/python/lsst/dax/ppdb/tests/_ppdb.py
@@ -25,6 +25,7 @@ __all__ = ["PpdbTest"]
 
 import unittest
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 import astropy.time
@@ -115,7 +116,9 @@ class PpdbTest(TestCaseMixin, ABC):
             apdb.store(visit_time, objects, sources, fsources)
             start_id += nobj
 
-    def _check_chunks(self, apdb_chunks: list[ReplicaChunk], ppdb_chunks: list[PpdbReplicaChunk]) -> None:
+    def _check_chunks(
+        self, apdb_chunks: Sequence[ReplicaChunk], ppdb_chunks: Sequence[PpdbReplicaChunk]
+    ) -> None:
         """Check PPDB replica chunks against APDB chunks."""
         self.assertLessEqual(len(ppdb_chunks), len(apdb_chunks))
         for i in range(len(ppdb_chunks)):


### PR DESCRIPTION
This PR cleans up the class structure and internal dependencies of the modules in the `bigquery` package which are related to replica chunk management using the SQL database.

**Improvements**

- Removed dependencies on the `_ppdb_sql` module.
  - Changed `ChunkExporter` so it implements the `Ppdb` abstract class instead of sub-classing `PpdbSql`.
    - Where needed, the `PpdbReplicaChunkSql` class is used as a delegate for necessary functionality.
  - Removed the `PpdbSql` parent class from `PpdbReplicaChunkSql`.
  - Added a new `ppdb_sql_utils.py` module where standalone functionality from `_ppdb_sql.py` was included, with some minor modifications.
  - Added a new `ppdb_sql_config` module which contains the `PpdbSqlConfig` class copied from `_ppdb_sql`.
    - Removed the `felis_name` and `felis_path` attributes and added `apdb_schema_uri`, which by default points to a resource path pointing to the APDB YAML schema installed into the environment.
- Modified the `Ppdb` class so that a `Sequence` of replica chunks is returned by `get_replica_chunks` instead of a `list`.
  - This makes the typing more flexible for implementers, as they may return a collection of objects which are sub-classes of `PpdbReplicaChunk`, as is done in the `bigquery` module. This is not possible if the `list` type is used, as it doesn't allow variadic types.
- Rewrote the functions for creating the `PpdbReplicaChunkSql` database so that only the `metadata` and `PpdbReplicaChunk` tables are created.
- Added a simple utility method in `_repica_chunk` for converting from the astropy times back to datetime for database inserts (used internally).
- Changed `PpdbBigQueryConfig` so that it directly sub-classes `PpdbConfig` instead of `PpdbSqlConfig`.
  - The SQL configuration, which is still needed for setting up the database for replica chunk management, is now included under a `sql` attribute containing the complete `ppdb_sql_config.PpdbSqlConfig`.
      
**Fixes**

- Fixed typing in `Ppdb` and its associated factory methods in the `_factory` module to return the generic `Ppdb` type rather than `PpdbSql`.
- Based on the above change to the `Ppdb` class (using `list` instead of `Sequence`), updated some test methods to fix mypy errors.
- Fixed miscellaneous typing and docstring errors.

**Notes**

There is significant code duplication introduced here between the new SQL modules (`ppdb_sql_config` and `ppdb_sql_utils`) and `_ppdb_sql`. This was intentional, because the idea in creating them was extracting standalone SQL-related functionality so that it could be reused, while leaving the old module the same, in order not to break it or introduce bugs. It is also my understanding that `_ppdb_sql` may be removed entirely at some point, so we do not want to depend on it from other modules. But there is still a lot of the functionality that it implements which is needed.

The `ppdb-cli create-bq-replica-chunk-sql` command was changed so that it does not generate a YAML config file any longer. This was because many other parameters are required for BigQuery, so it can't be used to generate a complete config. I will add a dedicated command under `ppdb-cli` for generating and writing out the `PpdbBigQueryConfig` on another ticket.