### PR TITLE
DM-50190: Add support for handling APDB update records

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -18,6 +18,9 @@ ignore_missing_imports = True
 [mypy-lsst.sphgeom]
 ignore_missing_imports = True
 
+[mypy-pandas.*]
+ignore_missing_imports = True
+
 [mypy-pyarrow.*]
 ignore_missing_imports = True
 

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -22,7 +22,7 @@
 import datetime
 import logging
 import shutil
-from collections.abc import Iterable, Sequence
+from collections.abc import Collection, Iterable, Sequence
 from pathlib import Path
 
 import felis
@@ -32,6 +32,7 @@ from lsst.dax.apdb import (
     ApdbMetadata,
     ApdbTableData,
     ApdbTables,
+    ApdbUpdateRecord,
     ReplicaChunk,
     VersionTuple,
     monitor,
@@ -151,11 +152,18 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         objects: ApdbTableData,
         sources: ApdbTableData,
         forced_sources: ApdbTableData,
+        update_records: Collection[ApdbUpdateRecord],
         *,
         update: bool = False,
     ) -> None:
         # Docstring is inherited.
         _LOG.info("Processing %s", replica_chunk.id)
+
+        # TODO: APDB does not generate ApdbUpdateRecords yet, but we will
+        # eventually have to add support for it.
+        if update_records:
+            raise NotImplementedError("PpdbBigQuery does not support record updates yet.")
+
         try:
             chunk_dir = self._get_chunk_path(replica_chunk)
 

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -24,12 +24,12 @@ from __future__ import annotations
 __all__ = ["Ppdb"]
 
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from dataclasses import dataclass
 
 import astropy.time
 
-from lsst.dax.apdb import ApdbMetadata, ApdbTableData, ReplicaChunk
+from lsst.dax.apdb import ApdbMetadata, ApdbTableData, ApdbUpdateRecord, ReplicaChunk
 from lsst.resources import ResourcePathExpression
 
 from ._factory import ppdb_from_config
@@ -116,6 +116,7 @@ class Ppdb(ABC):
         objects: ApdbTableData,
         sources: ApdbTableData,
         forced_sources: ApdbTableData,
+        update_records: Collection[ApdbUpdateRecord],
         *,
         update: bool = False,
     ) -> None:
@@ -131,6 +132,10 @@ class Ppdb(ABC):
             Matching APDB data for DiaSources.
         forced_sources : `~lsst.dax.apdb.ApdbTableData`
             Matching APDB data for DiaForcedSources.
+        update_records : `~collections.abc.Collection` \
+                [`~lsst.dax.apdb.ApdbUpdateRecord`]
+            Records of updates to be applied to pre-existing data. The records
+            must be in the same order as they were originally applied to APDB.
         update : `bool`, optional
             If `True` then allow updates for existing  data from the same
             ``replica_chunk``.

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -174,9 +174,20 @@ class Replicator:
             dia_forced_sources = self._apdb.getTableDataChunks(ApdbTables.DiaForcedSource, [replica_chunk.id])
             timer.add_values(row_count=len(dia_objects.rows()))
         _LOG.info("Selected %s DiaForcedSources for replication", len(dia_forced_sources.rows()))
+        with Timer("get_update_records_time", _MON) as timer:
+            update_records = self._apdb.getUpdateRecordChunks([replica_chunk.id])
+            timer.add_values(row_count=len(update_records))
+        _LOG.info("Selected %s DiaForcedSources for replication", len(dia_forced_sources.rows()))
 
         with Timer("store_chunks_time", _MON):
-            self._ppdb.store(replica_chunk, dia_objects, dia_sources, dia_forced_sources, update=self._update)
+            self._ppdb.store(
+                replica_chunk,
+                dia_objects,
+                dia_sources,
+                dia_forced_sources,
+                update_records,
+                update=self._update,
+            )
 
     def run(self, single: bool = False, exit_on_empty: bool = False) -> None:
         """Run the replication loop.

--- a/tests/config/schema.yaml
+++ b/tests/config/schema.yaml
@@ -191,6 +191,12 @@ tables:
     datatype: double
     nullable: false
     description: Time when the image was processed and this DiaSource record was generated.
+  - name: timeWithdrawnMjdTai
+    "@id": "#DiaSource.timeWithdrawnMjdTai"
+    datatype: double
+    nullable: true
+    description: Time when this record was marked invalid,
+      expressed as Modified Julian Date, International Atomic Time.
   primaryKey: "#DiaSource.diaSourceId"
   indexes:
   - name: IDX_DiaSource_visitDetector
@@ -264,6 +270,12 @@ tables:
     datatype: double
     nullable: false
     description: Time when this record was generated.
+  - name: timeWithdrawnMjdTai
+    "@id": "#DiaForcedSource.timeWithdrawnMjdTai"
+    datatype: double
+    nullable: true
+    description: Time when this record was marked invalid,
+      expressed as Modified Julian Date, International Atomic Time.
   primaryKey:
   - "#DiaForcedSource.diaObjectId"
   - "#DiaForcedSource.visit"

--- a/tests/test_ppdbBigQuery.py
+++ b/tests/test_ppdbBigQuery.py
@@ -24,6 +24,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from typing import Any
 
 from lsst.dax.apdb import ApdbConfig
@@ -54,7 +55,7 @@ class SqliteTestCase(PpdbTest, unittest.TestCase):
     def make_instance(self, **kwargs: Any) -> PpdbConfig:
         """Make config class instance used in all tests."""
         bq_config = PpdbBigQuery.init_database(db_url=self.ppdb_url, schema_file=TEST_SCHEMA, **kwargs)
-        bq_config.directory = self.tempdir
+        bq_config.directory = Path(self.tempdir)
         bq_config.delete_existing = True
         return bq_config
 
@@ -99,7 +100,7 @@ class PostgresTestCase(PpdbTest, unittest.TestCase):
     def make_instance(self, **kwargs: Any) -> PpdbConfig:
         """Make config class instance used in all tests."""
         bq_config = PpdbBigQuery.init_database(db_url=self.server.url(), schema_file=TEST_SCHEMA, **kwargs)
-        bq_config.directory = self.tempdir
+        bq_config.directory = Path(self.tempdir)
         bq_config.delete_existing = True
         return bq_config
 

--- a/tests/test_ppdbSql.py
+++ b/tests/test_ppdbSql.py
@@ -43,6 +43,8 @@ TEST_SCHEMA = os.path.join(os.path.abspath(os.path.dirname(__file__)), "config/s
 class ApdbSQLiteTestCase(PpdbTest, unittest.TestCase):
     """A test case for PpdbSql class using SQLite backend."""
 
+    include_update_records = True
+
     def setUp(self) -> None:
         self.tempdir = tempfile.mkdtemp()
         self.apdb_url = f"sqlite:///{self.tempdir}/apdb.sqlite3"
@@ -70,6 +72,8 @@ class ApdbPostgresTestCase(PpdbTest, unittest.TestCase):
     """A test case for ApdbSql class using Postgres backend."""
 
     postgresql: Any
+
+    include_update_records = True
 
     @classmethod
     def setUpClass(cls) -> None:


### PR DESCRIPTION
`ApdbUpdateRecord` and its subclasses represent non-regular updates to the APDB that need to be replicated to the PPDB (e.g. `DIASource` withdrawal). The `Ppdb.store()` method gets an additional argument which is a sequence (possibly empty) of ApdbUpdateRecords. The SQL backend adds support for propagating these updates, and the BQ implementation (`PpdbBigQuery`) for now just asserts that the list of updates is empty. The APDB currently does not generate any such records,
but we will start adding new update methods to the APDB soon.