### PR TITLE
DM-52936: Add optional `dax_ppdbx_gcp` dependency

### DIFF
--- a/ups/dax_ppdb.table
+++ b/ups/dax_ppdb.table
@@ -5,5 +5,7 @@ setupRequired(sconsUtils)
 setupRequired(sdm_schemas)
 setupRequired(utils)
 
+setupOptional(dax_ppdbx_gcp)
+
 envPrepend(PATH, ${PRODUCT_DIR}/bin)
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
See also https://github.com/lsst-dm/dax_ppdbx_gcp/pull/5 which fixes up the `dax_ppdbx_gcp` build so it can be added as an optional dependency here.