### PR TITLE
DM-53023: Remove hard-coded directory from the object prefix

### DIFF
--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -232,7 +232,8 @@ class ChunkUploader:
 
         # Construct the GCS prefix for this chunk's files.
         gcs_prefix = posixpath.join(
-            self.prefix, f"chunks/{manifest.exported_at.strftime('%Y/%m/%d')}/{chunk_id}"
+            self.prefix,
+            f"{manifest.exported_at.strftime('%Y/%m/%d')}/{chunk_id}",
         )
 
         # Make a list of local parquet files to upload.


### PR DESCRIPTION
This prepended directory is undesirable and was out of sync with the directory published in the Pub/Sub event. Using the object prefix from the PPDB config should be adequate, e.g., `data/chunks`.