### PR TITLE
DM-53401: Update unit tests with additional config option for APDB

### DIFF
--- a/tests/test_ppdbBigQuery.py
+++ b/tests/test_ppdbBigQuery.py
@@ -78,6 +78,7 @@ class SqliteTestCase(PpdbTest, unittest.TestCase):
         """Make APDB instance for tests."""
         kw = {
             "schema_file": TEST_SCHEMA,
+            "ss_schema_file": "",
             "db_url": self.apdb_url,
             "enable_replica": True,
         }
@@ -128,6 +129,7 @@ class PostgresTestCase(PpdbTest, unittest.TestCase):
     def make_apdb_instance(self, **kwargs: Any) -> ApdbConfig:
         kw = {
             "schema_file": TEST_SCHEMA,
+            "ss_schema_file": "",
             "db_url": self.server.url(),
             "namespace": "apdb",
             "enable_replica": True,

--- a/tests/test_ppdbSql.py
+++ b/tests/test_ppdbSql.py
@@ -60,6 +60,7 @@ class ApdbSQLiteTestCase(PpdbTest, unittest.TestCase):
     def make_apdb_instance(self, **kwargs: Any) -> ApdbConfig:
         kw = {
             "schema_file": TEST_SCHEMA,
+            "ss_schema_file": "",
             "db_url": self.apdb_url,
             "enable_replica": True,
         }
@@ -102,6 +103,7 @@ class ApdbPostgresTestCase(PpdbTest, unittest.TestCase):
     def make_apdb_instance(self, **kwargs: Any) -> ApdbConfig:
         kw = {
             "schema_file": TEST_SCHEMA,
+            "ss_schema_file": "",
             "db_url": self.server.url(),
             "namespace": "apdb",
             "enable_replica": True,


### PR DESCRIPTION
APDB configuration added a new optiopn whose default value cannot
be used in the unit tests.