### PR TITLE
Update doc build

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -1,0 +1,54 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build_sphinx_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need to clone everything for the git tags.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: "setup.cfg"
+
+      - name: Install uv
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
+
+      - name: Update wheel infrastructure
+        run: |
+          uv pip install --system wheel
+
+      - name: Install postgresql (server)
+        run: |
+          sudo apt-get update
+          sudo apt-get install postgresql
+
+      - name: Install dependencies
+        run: |
+          uv pip install --system -r requirements.txt
+
+      - name: Build and install
+        run: uv pip install --system --no-deps -v -e .
+
+      - name: Install graphviz
+        run: sudo apt-get install graphviz
+
+      - name: Install documenteer
+        run: uv pip install --system -r doc/requirements.txt
+
+      - name: Build documentation
+        working-directory: ./doc
+        run: package-docs build -n

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pytest_session.txt
 
 # VS Code
 .vscode
+
+# Generated Sphinx API doc
+doc/api

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -5,9 +5,4 @@ For more information, see:
 https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.conf.pipelinespkg import *
-
-project = "dax_ppdb"
-html_theme_options["logotext"] = project
-html_title = project
-html_short_title = project
+from documenteer.conf.guide import *

--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -1,0 +1,28 @@
+[project]
+title = "lsst-dax-ppdb"
+
+[project.python]
+package = "lsst-dax-ppdb"
+
+[build]
+clean = true
+
+[sphinx]
+nitpick_ignore = [
+    ["py:class", "dataset type expression"],
+    ["py:class", "collection expression"],
+    ["py:data", "typing.Union"],
+    ["py:class", "uuid.UUID"],
+]
+nitpick_ignore_regex = [
+    ['py:.*', 'pyarrow\..*'],
+    ['py:.*', 'sqlalchemy\..*'],  # not every sqlalchemy class resolves
+    ['py:.*', 'yaml\..*'],  # YAML has no sphinx docs
+]
+
+[sphinx.intersphinx.projects]
+astropy = "https://docs.astropy.org/en/stable"
+python = "https://docs.python.org/3"
+lsst = "https://pipelines.lsst.io/v/daily/"
+sqlalchemy = "https://docs.sqlalchemy.org/en/20/"
+pandas = "https://pandas.pydata.org/docs/"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,3 +53,15 @@ Python API reference
 .. automodapi:: lsst.dax.ppdb.bigquery
    :no-main-docstr:
    :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.cli
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.scripts
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.sql
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,3 @@
+documenteer[guide] > 2.0, <3.0
+lsst-sphinxutils @ git+https://github.com/lsst/sphinxutils@main
+sphinx-click

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/lsst/dax_ppdb"
+"Source" = "https://github.com/lsst/dax_ppdb"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
This updates the repo to use the latest version of the LTD toolchain so that it is buildable using `package-docs build` from `lsst-scipipe`. 

The `build_docs.yaml` workflow was also copied from Butler, and additional packages were added to `index.rst`. There are build warnings, so `-W` is not enabled in the build right now until those are fixed (on a separate PR).