### PR TITLE
DM-54653: Fix documentation and linting issues

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Build documentation
         working-directory: ./doc
-        run: package-docs build -n
+        run: package-docs build -n -W

--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -12,7 +12,6 @@ nitpick_ignore = [
     ["py:class", "dataset type expression"],
     ["py:class", "collection expression"],
     ["py:data", "typing.Union"],
-    ["py:class", "uuid.UUID"],
 ]
 nitpick_ignore_regex = [
     ['py:.*', 'pyarrow\..*'],
@@ -26,3 +25,5 @@ python = "https://docs.python.org/3"
 lsst = "https://pipelines.lsst.io/v/daily/"
 sqlalchemy = "https://docs.sqlalchemy.org/en/20/"
 pandas = "https://pandas.pydata.org/docs/"
+google_cloud_bigquery = "https://googleapis.dev/python/bigquery/latest/"
+google_api_core = "https://googleapis.dev/python/google-api-core/latest/"

--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -7,18 +7,6 @@ package = "lsst-dax-ppdb"
 [build]
 clean = true
 
-[sphinx]
-nitpick_ignore = [
-    ["py:class", "dataset type expression"],
-    ["py:class", "collection expression"],
-    ["py:data", "typing.Union"],
-]
-nitpick_ignore_regex = [
-    ['py:.*', 'pyarrow\..*'],
-    ['py:.*', 'sqlalchemy\..*'],  # not every sqlalchemy class resolves
-    ['py:.*', 'yaml\..*'],  # YAML has no sphinx docs
-]
-
 [sphinx.intersphinx.projects]
 astropy = "https://docs.astropy.org/en/stable"
 python = "https://docs.python.org/3"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,10 @@ Python API reference
    :no-main-docstr:
    :no-inheritance-diagram:
 
+.. automodapi:: lsst.dax.ppdb.bigquery.updates
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
 .. automodapi:: lsst.dax.ppdb.cli
    :no-main-docstr:
    :no-inheritance-diagram:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ checks = [
     "RT01",  # Unfortunately our @property trigger this.
     "RT02",  # Does not want named return value. DM style says we do.
     "SS05",  # pydocstyle is better at finding infinitive verb.
+    "PR04",  # New Sphinx can infer types from python typing.
 ]
 exclude = [
     "^test_.*",  # Do not test docstrings in test code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ zip-safe = true
 
 [tool.setuptools.package-data]
 "lsst.dax.ppdb" = [
-    "py.typed", 
-    "resources/config/schemas/*.yaml", 
+    "py.typed",
+    "resources/config/schemas/*.yaml",
     "resources/config/sql/*.sql",
 ]
 
@@ -118,7 +118,8 @@ select = [
     "B",       # flake8-bugbear
 ]
 extend-select = [
-    "RUF100", # Warn about unused noqa
+    "RUF100",  # Warn about unused noqa
+    "D212",    # Multi-line docstring summary should start at the second line.
 ]
 
 [tool.ruff.lint.isort]

--- a/python/lsst/dax/ppdb/_arrow.py
+++ b/python/lsst/dax/ppdb/_arrow.py
@@ -46,7 +46,7 @@ def _felis_to_arrow_type(felis_type: DataType) -> pyarrow.DataType:
 
     Parameters
     ----------
-    felis_type : `felis.datamodel.DataType`
+    felis_type
         Felis data type to convert.
 
     Returns
@@ -67,9 +67,9 @@ def create_arrow_schema(
 
     Parameters
     ----------
-    column_defs : `Sequence` [ `tuple` [ `str`, `felis.datamodel.DataType` ] ]
+    column_defs
         Column name and type pairs.
-    exclude_columns : `set` [`str`], optional
+    exclude_columns
         Column names to exclude from the schema.
 
     Returns
@@ -97,18 +97,18 @@ def write_parquet(
 
     Parameters
     ----------
-    table_name : `str`
+    table_name
         Logical table name (for logging and error messages).
-    table_data : `lsst.dax.apdb.ApdbTableData`
+    table_data
         The APDB table data to write.
-    file_path : `pathlib.Path`
+    file_path
         Destination Parquet file path.
-    batch_size : `int`, optional
+    batch_size
         Number of rows to write in each batch. If `None`, defaults to 1000.
-    compression_format : `str`, optional
+    compression_format
         Compression format to use for the Parquet file. If `None`, defaults
         to "snappy".
-    exclude_columns : `set` [ `str` ], optional
+    exclude_columns
         Set of column names to exclude from the Parquet file. These
         exclusions apply to all of the tables. Default is an empty set,
         meaning no columns are excluded.

--- a/python/lsst/dax/ppdb/_arrow.py
+++ b/python/lsst/dax/ppdb/_arrow.py
@@ -51,7 +51,7 @@ def _felis_to_arrow_type(felis_type: DataType) -> pyarrow.DataType:
 
     Returns
     -------
-    arrow_type : `pyarrow.DataType`
+    `pyarrow.DataType`
         Corresponding Arrow data type.
     """
     if arrow_type := _FELIS_TYPE_MAP.get(felis_type):
@@ -74,7 +74,7 @@ def create_arrow_schema(
 
     Returns
     -------
-    schema : `pyarrow.Schema`
+    `pyarrow.Schema`
         The resulting schema.
     """
     if exclude_columns is None:
@@ -115,7 +115,7 @@ def write_parquet(
 
     Returns
     -------
-    total : `int`
+    `int`
         Total number of rows written to the Parquet file.
     """
     rows = list(table_data.rows())

--- a/python/lsst/dax/ppdb/_factory.py
+++ b/python/lsst/dax/ppdb/_factory.py
@@ -40,7 +40,7 @@ def config_type_for_name(type_name: str) -> type[PpdbConfig]:
 
     Returns
     -------
-    type : `type` [ `PpdbConfig` ]
+    `type` [ `PpdbConfig` ]
         Subclass of `PpdbConfig` class.
 
     Raises
@@ -71,7 +71,7 @@ def ppdb_from_config(config: PpdbConfig) -> Ppdb:
 
     Returns
     -------
-    ppdb : `Ppdb`
+    `Ppdb`
         Instance of `Ppdb` class.
 
     Raises

--- a/python/lsst/dax/ppdb/_factory.py
+++ b/python/lsst/dax/ppdb/_factory.py
@@ -35,7 +35,7 @@ def config_type_for_name(type_name: str) -> type[PpdbConfig]:
 
     Parameters
     ----------
-    type_name : `str`
+    type_name
         Short type name of Ppdb implement, for now only "sql" is supported.
 
     Returns
@@ -65,7 +65,7 @@ def ppdb_from_config(config: PpdbConfig) -> Ppdb:
 
     Parameters
     ----------
-    config : `PpdbConfig`
+    config
         Configuration object, type of this object determines type of the
         Ppdb implementation.
 

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -85,7 +85,7 @@ class ChunkPromoter:
         )
 
         # Build a mapping of phases to run during the promotion process, not
-        # including cleanup, which is executed separately
+        # including cleanup, which is executed separately.
         _phase_methods = [
             self._copy_to_promoted_tmp,
             self._apply_record_updates,
@@ -130,17 +130,17 @@ class ChunkPromoter:
             # Clone prod table structure and data (zero-copy)
             self._runner.run_job("clone_prod", f"CREATE TABLE `{tmp_ref}` CLONE `{prod_ref}`")
 
-            # Build ordered target list from the cloned tmp schema
+            # Build ordered target list from the cloned tmp schema.
             tmp_schema = self._bq_client.get_table(tmp_ref).schema
             target_names = [f.name for f in tmp_schema if f.name != "apdb_replica_chunk"]
             target_list_sql = ", ".join(f"`{n}`" for n in target_names)
 
-            # Build source list, handling geo_point conversion
+            # Build source list, handling geo_point conversion.
             source_list_sql = ", ".join(
                 "ST_GEOGPOINT(s.`ra`, s.`dec`)" if n == "geo_point" else f"s.`{n}`" for n in target_names
             )
 
-            # Insert staged rows into tmp, excluding apdb_replica_chunk column
+            # Insert staged rows into tmp, excluding apdb_replica_chunk column.
             sql = f"""
             INSERT INTO `{tmp_ref}` ({target_list_sql})
             SELECT {source_list_sql}
@@ -157,13 +157,13 @@ class ChunkPromoter:
         dataset.
         """
         for prod_ref, tmp_ref in zip(self._table_refs.prod, self._table_refs.promoted_tmp, strict=True):
-            # Ensure tmp exists
+            # Ensure tmp exists.
             try:
                 self._bq_client.get_table(tmp_ref)
             except NotFound as e:
                 raise RuntimeError(f"Missing tmp table for promotion: {tmp_ref}") from e
 
-            # Atomic zero-copy replacement of prod with tmp
+            # Perform an atomic, zero-copy replacement of prod with tmp.
             copy_cfg = bigquery.CopyJobConfig(write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE)
             job = self._bq_client.copy_table(
                 tmp_ref, prod_ref, job_config=copy_cfg, location=self._runner.location

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -56,9 +56,9 @@ class ChunkPromoter:
 
     Parameters
     ----------
-    ppdb : `PpdbBigQuery`
+    ppdb
         Interface to the PPDB in BigQuery.
-    table_names : `list`[`str`], optional
+    table_names
         List of table names to promote or if None a default list will be used.
     """
 

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -49,9 +49,9 @@ class ChunkUploadError(RuntimeError):
 
     Parameters
     ----------
-    chunk_id : `int`
+    chunk_id
         The ID of the chunk being processed when the error occurred.
-    message : `str`
+    message
         A message describing the error.
     """
 
@@ -68,18 +68,18 @@ class ChunkUploader:
 
     Parameters
     ----------
-    ppdb : `PpdbBigQuery`
+    ppdb
         The PPDB interface which must have the type `PpdbBigQuery`.
-    wait_interval : `int`
+    wait_interval
         The time in seconds to wait between scans for new chunks.
-    upload_interval : `int`
+    upload_interval
         The time in seconds to wait between uploads of files.
         Setting this to a value greater than 0 will cause the
         uploader to wait for this amount of time before processing the next
         chunk after a successful upload.
-    exit_on_empty : `bool`
+    exit_on_empty
         If `True`, the uploader will exit if no files are found during a scan.
-    exit_on_error : `bool`
+    exit_on_error
         If `True`, the uploader will exit if an error occurs during upload.
 
     Notes
@@ -180,7 +180,7 @@ class ChunkUploader:
 
         Parameters
         ----------
-        replica_chunk : `PpdbReplicaChunk`
+        replica_chunk
             The replica chunk to process, which includes its ID and directory.
 
         Raises

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -88,12 +88,12 @@ class ChunkUploader:
     ``PpdbReplicaChunk`` table in the PPDB (Postgres) database. Chunks with a
     status of "exported", meaning their table data has been written locally
     to parquet files, will be uploaded to a Google Cloud Storage (GCS) bucket.
-    The `exit_on_empty` flag controls whether the process exits if no new
+    The ``exit_on_empty`` flag controls whether the process exits if no new
     chunks are found after a query. The process will also exit if there is an
-    exception and the `exit_on_error` flag is set to `True`. The
-    `wait_interval` controls how often the process will query the database for
-    new chunks, and the `upload_interval` controls the wait interval between
-    uploading the files for a single chunk.
+    exception and the ``exit_on_error`` flag is set to `True`. The
+    ``wait_interval`` controls how often the process will query the database
+    for new chunks, and the ``upload_interval`` controls the wait interval
+    between uploading the files for a single chunk.
     """
 
     def __init__(

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -104,19 +104,19 @@ class ChunkUploader:
         exit_on_empty: bool = False,
         exit_on_error: bool = False,
     ):
-        # Setup interface for accessing replica chunk data
+        # Setup interface for accessing replica chunk data.
         self._ppdb = ppdb
 
-        # Command line parameters
+        # Set parameters from the command line options or their defaults.
         self._wait_interval = wait_interval
         self._upload_interval = upload_interval
         self._exit_on_empty = exit_on_empty
         self._exit_on_error = exit_on_error
 
-        # Initialize the storage client for interacting with GCS
+        # Initialize the storage client for interacting with GCS.
         self._storage = StorageClient(bucket_name=self.config.bucket_name)
 
-        # Initialize the Pub/Sub publisher for staging chunks in BigQuery
+        # Initialize the Pub/Sub publisher for staging chunks in BigQuery.
         self._publisher = Publisher(self.config.project_id, self.config.stage_chunk_topic)
 
     @property
@@ -134,7 +134,7 @@ class ChunkUploader:
 
             try:
                 # Get replica chunks that have been exported and are ready for
-                # upload to cloud storage
+                # upload to cloud storage.
                 replica_chunks = self._ppdb.get_replica_chunks_ext(status=ChunkStatus.EXPORTED)
             except Exception:
                 # Some problem occurred while retrieving replica chunk data.
@@ -150,7 +150,7 @@ class ChunkUploader:
                 _LOG.info("Found %d replica chunks ready for upload", len(replica_chunks))
                 for replica_chunk in replica_chunks:
                     try:
-                        # Process each replica chunk
+                        # Process each replica chunk.
                         _LOG.info("Processing %d", replica_chunk.id)
                         self._process_chunk(replica_chunk)
                     except ChunkUploadError:
@@ -195,7 +195,7 @@ class ChunkUploader:
             raise ChunkUploadError(chunk_id, "No directory specified on replica chunk")
         chunk_dir = replica_chunk.directory
 
-        # Read the manifest file to get metadata about the chunk
+        # Read the manifest file to get metadata about the chunk.
         manifest: Manifest | None = None
         try:
             if not replica_chunk.manifest_path.exists():
@@ -206,16 +206,16 @@ class ChunkUploader:
         except Exception as e:
             raise ChunkUploadError(chunk_id, f"Failed to read manifest file for: {replica_chunk.id}") from e
 
-        # Construct the GCS prefix for this chunk's files
+        # Construct the GCS prefix for this chunk's files.
         gcs_prefix = posixpath.join(
             self.config.object_prefix,
             f"{manifest.exported_at.strftime('%Y/%m/%d')}/{chunk_id}",
         )
 
-        # Make a list of local parquet files to upload
+        # Make a list of local parquet files to upload.
         upload_file_list = list(chunk_dir.glob("*.parquet"))
 
-        # Check if the chunk is expected to be empty
+        # Check if the chunk is expected to be empty.
         is_empty = manifest.is_empty_chunk()
 
         # Raise an error if no files are present for non-empty chunks since
@@ -246,7 +246,7 @@ class ChunkUploader:
                 )
 
         try:
-            # 1) Upload the files to GCS for non-empty chunks
+            # 1) Upload the files to GCS for non-empty chunks.
             if upload_file_list:
                 gcs_names = {path: posixpath.join(gcs_prefix, path.name) for path in upload_file_list}
                 try:
@@ -260,7 +260,7 @@ class ChunkUploader:
                 except* UploadError as eg:
                     raise ChunkUploadError(chunk_id, f"{len(eg.exceptions)} upload(s) failed") from eg
 
-            # 2) Upload manifest, even for empty chunks
+            # 2) Upload manifest, even for empty chunks.
             try:
                 self._storage.upload_from_string(
                     posixpath.join(gcs_prefix, Path(replica_chunk.manifest_path).name),
@@ -306,7 +306,7 @@ class ChunkUploader:
                 self._storage.delete_recursive(gcs_prefix)
             except DeleteError as cleanup_err:
                 # Note (Python 3.11+): annotate without masking the
-                # original error
+                # original error.
                 err.add_note(f"cleanup warning: failed to delete gs://{gcs_uri}: {cleanup_err}")
             raise
 

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -91,7 +91,7 @@ class Manifest(BaseModel):
 
         Parameters
         ----------
-        dir_path : `Path`
+        dir_path
             Path to the directory where the manifest file should be written.
         """
         file_path = os.path.join(dir_path, self.FILE_NAME)
@@ -104,7 +104,7 @@ class Manifest(BaseModel):
 
         Parameters
         ----------
-        file_path : `pathlib.Path`
+        file_path
             Path to the JSON file containing the manifest.
 
         Returns
@@ -122,7 +122,7 @@ class Manifest(BaseModel):
 
         Parameters
         ----------
-        content : `str`
+        content
             The string with the JSON data.
         """
         data = json.loads(content)

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -109,7 +109,7 @@ class Manifest(BaseModel):
 
         Returns
         -------
-        manifest : `Manifest`
+        `Manifest`
             The loaded manifest object.
         """
         with open(file_path, encoding="utf-8") as f:
@@ -134,7 +134,7 @@ class Manifest(BaseModel):
 
         Returns
         -------
-        empty : `bool`
+        `bool`
             `True` if all tables have zero rows and no update records are
             included, indicating an empty chunk, `False` otherwise.
         """

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -114,7 +114,7 @@ class PpdbBigQueryConfig(PpdbConfig):
 
         Returns
         -------
-        fq_dataset_id : `str`
+        `str`
             Fully qualified BigQuery dataset ID, including project.
         """
         return f"{self.project_id}:{self.dataset_id}"
@@ -191,7 +191,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        ppdb: `PpdbBigQuery`
+        `PpdbBigQuery`
             An instance of the PPDB BigQuery interface.
         """
         ppdb_config_uri = os.environ.get("PPDB_CONFIG_URI", None)
@@ -322,7 +322,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        chunk_dir : `pathlib.Path`
+        `pathlib.Path`
             Path to the created directory for the replica chunk.
         """
         last_update_time = chunk.last_update_time.to_datetime()
@@ -365,7 +365,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        chunks : `~collections.abc.Sequence` [ `PpdbReplicaChunkExtended` ]
+        `~collections.abc.Sequence` [ `PpdbReplicaChunkExtended` ]
             List of chunks with the specified status. Chunks are ordered by
             their ``last_update_time`` and include the ``directory`` and
             ``status`` fields.
@@ -415,7 +415,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        chunks : `~collections.abc.Sequence` [ `PpdbReplicaChunkExtended` ]
+        `~collections.abc.Sequence` [ `PpdbReplicaChunkExtended` ]
             List of matching chunks ordered by ``apdb_replica_chunk``.
         """
         if not chunk_ids:
@@ -761,7 +761,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        chunk_ids : `list`[`int`]
+        `list`[`int`]
             A list of tuples containing the ``apdb_replica_chunk`` values of
             the promotable chunks.
 
@@ -802,7 +802,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        count: `int`
+        `int`
             The number of rows updated in the database, which should be equal
             to the number of promotable chunks provided, if they were all found
             and updated successfully.
@@ -830,7 +830,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        count : `int`
+        `int`
             The number of rows updated. This should be 1 if the update is
             successful, or 0 if no rows were updated (e.g., if the chunk ID
             does not exist or the status is already set to the new value).

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -176,7 +176,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
     @property
     def metadata(self) -> ApdbMetadata:
-        """APDB metadata object from `Ppdb` interface (`ApdbMetadata`)."""
+        """APDB metadata object from `~lsst.dax.ppdb.Ppdb` interface
+        (`~lsst.dax.apdb.ApdbMetadata`).
+        """
         return self._metadata
 
     @property
@@ -761,7 +763,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Returns
         -------
-        `list`[`int`]
+        `list` [`int`]
             A list of tuples containing the ``apdb_replica_chunk`` values of
             the promotable chunks.
 

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -125,9 +125,9 @@ class _SecretManagerPasswordProvider(PasswordProvider):
 
     Parameters
     ----------
-    project_id : `str`
+    project_id
         GCP project that owns the secret.
-    secret_name : `str`, optional
+    secret_name
         Name of the secret. Defaults to ``"ppdb-db-password"``.
     """
 
@@ -153,7 +153,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
     Parameters
     ----------
-    config : `PpdbBigQueryConfig`
+    config
         Configuration object with BigQuery and SQL database parameters.
     """
 
@@ -317,7 +317,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        chunk : `ReplicaChunk`
+        chunk
             The replica chunk for which to create the directory.
 
         Returns
@@ -357,9 +357,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        status : `ChunkStatus`
+        status
             Status of the replica chunks to return.
-        start_chunk_id : `int`, optional
+        start_chunk_id
             If provided, only return chunks with ID greater than or equal to
             this value.
 
@@ -410,7 +410,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        chunk_ids : `~collections.abc.Sequence` [ `int` ]
+        chunk_ids
             Replica chunk IDs to retrieve.
 
         Returns
@@ -463,9 +463,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        replica_chunk : `PpdbReplicaChunkExtended`
+        replica_chunk
             The replica chunk to store.
-        update : `bool`
+        update
             If `True` then perform an UPSERT operation to update existing
             records. If `False` then only INSERT is performed and an error is
             raised if the record already exists.
@@ -496,7 +496,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        table_name : `str`, optional
+        table_name
             Name of the table to create. If not provided, defaults to
             "PpdbReplicaChunk".
 
@@ -573,36 +573,36 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        db_url : `str`
+        db_url
             Database URL in SQLAlchemy format for PPDB instance.
-        project_id : `str`
+        project_id
             GCP project ID.
-        dataset_id : `str`
+        dataset_id
             BigQuery dataset name without the project ID.
-        bucket_name : `str`
+        bucket_name
             GCS bucket name to use for Parquet output.
-        object_prefix : `str`
+        object_prefix
             Object prefix to use in GCS bucket for Parquet output.
-        replication_dir : `str`
+        replication_dir
             Directory used for replication staging area.
-        db_drop : `bool`
+        db_drop
             If True then drop existing db tables.
-        db_schema : `str`, optional
+        db_schema
             Database schema name for PPDB instance.
-        felis_path : `str`, optional
+        felis_path
             Path to Felis database. If `None`, defaults to the default path in
             SDM Schemas.
-        felis_schema : `str`, optional
+        felis_schema
             Felis schema name within the YAML file.
-        stage_chunk_topic : `str`, optional
+        stage_chunk_topic
             Pub/Sub topic to use for staging chunks.
-        parq_batch_size : `int`, optional
+        parq_batch_size
             Number of rows to use when batching Parquet output.
-        parq_compression : `str`, optional
+        parq_compression
             Compression codec to use for Parquet output.
-        delete_existing_dirs : `bool`, optional
+        delete_existing_dirs
             If True then delete existing replication staging directories.
-        validate_config : `bool`, optional
+        validate_config
             If `True`, validate the configuration against GCP resources.
 
         Raises
@@ -669,7 +669,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        config : `PpdbBigQueryConfig`
+        config
             Configuration to validate.
 
         Raises
@@ -732,9 +732,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        replica_chunk : `ReplicaChunk`
+        replica_chunk
             The replica chunk associated with the updates.
-        update_records : `~collections.abc.Collection` [ `ApdbUpdateRecord` ]
+        update_records
             Collection of update records to process.
 
         Notes
@@ -796,7 +796,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        promotable_chunks : `list`[`int`]
+        promotable_chunks
             List of integers containing the ``apdb_replica_chunk`` values of
             the promotable chunks.
 
@@ -823,9 +823,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        chunk_id : `int`
+        chunk_id
             The ID of the replica chunk to update.
-        values : `dict`[`str`, `Any`]
+        values
             A dictionary of column names and their new values to update.
 
         Returns

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -756,9 +756,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         )
 
     def get_promotable_chunks(self) -> list[int]:
-        """
-        Return the first uninterrupted sequence of staged chunks such that all
-        prior chunks are promoted.
+        """Return the first uninterrupted sequence of staged chunks such that
+        all prior chunks are promoted.
 
         Returns
         -------

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -158,18 +158,18 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
     """
 
     def __init__(self, config: PpdbBigQueryConfig):
-        # Read parameters from config
+        # Read parameters from config.
         if config.replication_dir is None:
             raise ValueError("Directory for chunk export is not set in configuration.")
 
-        # Build an optional password provider for GCP Secret Manager
+        # Build an optional password provider for GCP Secret Manager.
         password_provider: PasswordProvider | None = None
         if os.getenv("PPDB_USE_SECRET_MANAGER", "false").lower() == "true":
             _LOG.debug("Using Secret Manager to retrieve database password")
             password_provider = _SecretManagerPasswordProvider(config.project_id)
 
         # Delegate SQL initialisation (schema load, engine, metadata, version
-        # checks) to the base class, passing the optional password provider
+        # checks) to the base class, passing the optional password provider.
         PpdbSqlBase.__init__(self, config.sql, password_provider=password_provider)
 
         self._config = config

--- a/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
@@ -103,11 +103,11 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Parameters
         ----------
-        replica_chunk : `ReplicaChunk`
+        replica_chunk
             The `ReplicaChunk` to convert.
-        status : `ChunkStatus`
+        status
             Status of the replica chunk.
-        directory : `pathlib.Path`
+        directory
             Directory where the replica chunk data is stored.
 
         Returns
@@ -131,7 +131,7 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Parameters
         ----------
-        new_status : `ChunkStatus`
+        new_status
             The new status to set.
 
         Returns
@@ -147,7 +147,7 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Parameters
         ----------
-        new_gcs_uri : `str`
+        new_gcs_uri
             The new GCS URI to set.
 
         Returns

--- a/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
@@ -112,7 +112,7 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Returns
         -------
-        extended_chunk : `PpdbReplicaChunkExtended`
+        `PpdbReplicaChunkExtended`
             The converted `PpdbReplicaChunkExtended`.
         """
         return PpdbReplicaChunkExtended(
@@ -136,7 +136,7 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Returns
         -------
-        new_chunk : `PpdbReplicaChunkExtended`
+        `PpdbReplicaChunkExtended`
             The new chunk with the updated status.
         """
         return dataclasses.replace(self, status=new_status)
@@ -152,7 +152,7 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
 
         Returns
         -------
-        new_chunk : `PpdbReplicaChunkExtended`
+        `PpdbReplicaChunkExtended`
             The new chunk with the updated GCS URI.
         """
         return dataclasses.replace(self, gcs_uri=new_gcs_uri)

--- a/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
@@ -28,8 +28,12 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import astropy.time
+
+if TYPE_CHECKING:
+    import uuid  # noqa: F401 (needed for autodoc to resolve inherited annotations)
 
 from lsst.dax.apdb import ReplicaChunk
 
@@ -99,12 +103,13 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
         directory: Path,
         update_count: int = 0,
     ) -> PpdbReplicaChunkExtended:
-        """Create a `PpdbReplicaChunkExtended` from a `ReplicaChunk`.
+        """Create a `PpdbReplicaChunkExtended` from a
+        `~lsst.dax.apdb.ReplicaChunk`.
 
         Parameters
         ----------
         replica_chunk
-            The `ReplicaChunk` to convert.
+            The `~lsst.dax.apdb.ReplicaChunk` to convert.
         status
             Status of the replica chunk.
         directory

--- a/python/lsst/dax/ppdb/bigquery/query_runner.py
+++ b/python/lsst/dax/ppdb/bigquery/query_runner.py
@@ -122,6 +122,11 @@ class QueryRunner:
             additional details.
         """
         job = self._bq_client.query(sql, job_config=job_config, location=self.dataset.location)
-        job.result()  # Wait for the job to complete
+
+        # Wait for the job to complete.
+        job.result()
+
+        # Log the job details.
         self.log_job(job, label)
+
         return job

--- a/python/lsst/dax/ppdb/bigquery/query_runner.py
+++ b/python/lsst/dax/ppdb/bigquery/query_runner.py
@@ -48,7 +48,9 @@ class QueryRunner:
 
     @property
     def dataset(self) -> bigquery.Dataset:
-        """Dataset reference (`bigquery.Dataset`, read-only)."""
+        """Dataset reference (`google.cloud.bigquery.dataset.Dataset`,
+        read-only).
+        """
         return self._dataset
 
     @property
@@ -116,7 +118,7 @@ class QueryRunner:
 
         Returns
         -------
-        `bigquery.job.QueryJob`
+        `google.cloud.bigquery.job.QueryJob`
             The BigQuery job object representing the executed query. This can
             be used to check the status of the job, retrieve results, or log
             additional details.

--- a/python/lsst/dax/ppdb/bigquery/query_runner.py
+++ b/python/lsst/dax/ppdb/bigquery/query_runner.py
@@ -116,7 +116,7 @@ class QueryRunner:
 
         Returns
         -------
-        job: `bigquery.job.QueryJob`
+        `bigquery.job.QueryJob`
             The BigQuery job object representing the executed query. This can
             be used to check the status of the job, retrieve results, or log
             additional details.

--- a/python/lsst/dax/ppdb/bigquery/query_runner.py
+++ b/python/lsst/dax/ppdb/bigquery/query_runner.py
@@ -35,9 +35,9 @@ class QueryRunner:
 
     Parameters
     ----------
-    project_id : `str`
+    project_id
         Google Cloud project ID.
-    dataset_id : `str`
+    dataset_id
         BigQuery dataset ID.
     """
 
@@ -73,12 +73,12 @@ class QueryRunner:
 
         Parameters
         ----------
-        job : `bigquery.job.QueryJob`
+        job
             The BigQuery job to log.
-        label : `str`
+        label
             A label for the job, typically indicating the type of operation
             (e.g., "insert", "delete", "copy").
-        level : `int`, optional
+        level
             The logging level to use for the log message. Defaults to
             `logging.DEBUG`.
         """
@@ -104,12 +104,12 @@ class QueryRunner:
 
         Parameters
         ----------
-        label : `str`
+        label
             A label for the job, typically indicating the type of operation
             (e.g., "insert", "delete", "copy").
-        sql : `str`
+        sql
             The SQL query to execute.
-        job_config : `bigquery.QueryJobConfig`, optional
+        job_config
             Configuration for the job, such as query parameters or write
             dispositions. If not provided, a default configuration will be
             used.

--- a/python/lsst/dax/ppdb/bigquery/sql_resource.py
+++ b/python/lsst/dax/ppdb/bigquery/sql_resource.py
@@ -33,8 +33,8 @@ class SqlResource:
     ----------
     sql_resource_name
         Base name of the SQL file (without .sql extension) containing the
-        query in the `resources/config/sql` directory within the
-        `lsst.dax.ppdb` package.
+        query in the ``resources/config/sql`` directory within the
+        ``lsst.dax.ppdb`` package.
     format_args
         Optional dictionary of arguments for formatting the SQL text.
     """

--- a/python/lsst/dax/ppdb/bigquery/sql_resource.py
+++ b/python/lsst/dax/ppdb/bigquery/sql_resource.py
@@ -31,11 +31,11 @@ class SqlResource:
 
     Parameters
     ----------
-    sql_resource_name : `str`
+    sql_resource_name
         Base name of the SQL file (without .sql extension) containing the
         query in the `resources/config/sql` directory within the
         `lsst.dax.ppdb` package.
-    format_args : `dict` [ `str`, `str` ], optional
+    format_args
         Optional dictionary of arguments for formatting the SQL text.
     """
 

--- a/python/lsst/dax/ppdb/bigquery/table_refs.py
+++ b/python/lsst/dax/ppdb/bigquery/table_refs.py
@@ -35,15 +35,15 @@ class TableRefs(BaseModel, frozen=True):
 
     Parameters
     ----------
-    project_id : `str`
+    project_id
         GCP project ID.
-    dataset_id : `str`
+    dataset_id
         BigQuery dataset ID.
-    table_names : `tuple` [`str`, ...]
+    table_names
         Base table names.
-    staging_format : `str`, optional
+    staging_format
         Format string for staging table names.
-    promoted_tmp_format : `str`, optional
+    promoted_tmp_format
         Format string for promoted temporary table names.
     """
 

--- a/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
@@ -54,7 +54,7 @@ class UpdateRecordExpander:
 
         Returns
         -------
-        expanded_records : `list` [ `ExpandedUpdateRecord` ]
+        `list` [ `ExpandedUpdateRecord` ]
             List of ExpandedUpdateRecord objects, one per field being updated.
         """
         # Get the target table from the update record.
@@ -92,7 +92,7 @@ class UpdateRecordExpander:
 
         Returns
         -------
-        expanded_updates : `list` [ `ExpandedUpdateRecord` ]
+        `list` [ `ExpandedUpdateRecord` ]
             A list of individual updates derived from the input update records.
         """
         expanded_updates = []

--- a/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
@@ -57,10 +57,10 @@ class UpdateRecordExpander:
         expanded_records : `list` [ `ExpandedUpdateRecord` ]
             List of ExpandedUpdateRecord objects, one per field being updated.
         """
-        # Get the target table from the update record
+        # Get the target table from the update record.
         table_name = update_record.apdb_table.name
 
-        # Create an ExpandedUpdateRecord for each field being updated
+        # Create an ExpandedUpdateRecord for each field being updated.
         expanded_records = []
         record_id_values = tuple(value for _, value in update_record.record_id())
         for field_name, field_value in update_record.record_payload():

--- a/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/update_record_expander.py
@@ -47,9 +47,9 @@ class UpdateRecordExpander:
 
         Parameters
         ----------
-        update_record : `ApdbUpdateRecord`
+        update_record
             A single APDB update record to expand.
-        replica_chunk_id : `int`
+        replica_chunk_id
             The replica chunk ID associated with this update record.
 
         Returns
@@ -85,9 +85,9 @@ class UpdateRecordExpander:
 
         Parameters
         ----------
-        update_records : `UpdateRecords`
+        update_records
             The APDB update records to expand.
-        replica_chunk_id : `int`
+        replica_chunk_id
             The replica chunk ID associated with these update records.
 
         Returns

--- a/python/lsst/dax/ppdb/bigquery/updates/update_records.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/update_records.py
@@ -97,7 +97,7 @@ class UpdateRecords:
 
         Returns
         -------
-        update_records : `UpdateRecords`
+        `UpdateRecords`
             The deserialized update records.
         """
         with open(path, "rb") as f:
@@ -114,7 +114,7 @@ class UpdateRecords:
 
         Returns
         -------
-        update_records : `UpdateRecords`
+        `UpdateRecords`
             The deserialized update records.
         """
         table = parquet.read_table(BytesIO(data), schema=cls._PARQUET_SCHEMA)

--- a/python/lsst/dax/ppdb/bigquery/updates/update_records.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/update_records.py
@@ -38,7 +38,7 @@ class UpdateRecords:
 
     Parameters
     ----------
-    records : `list` [ `ApdbUpdateRecord` ]
+    records
         List of APDB update records.
     """
 
@@ -65,7 +65,7 @@ class UpdateRecords:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Destination Parquet file path.
         """
         update_times: list[int] = []
@@ -92,7 +92,7 @@ class UpdateRecords:
 
         Parameters
         ----------
-        path : `pathlib.Path`
+        path
             Path to the Parquet file.
 
         Returns
@@ -109,7 +109,7 @@ class UpdateRecords:
 
         Parameters
         ----------
-        data : `bytes`
+        data
             Parquet file content as bytes.
 
         Returns

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -136,13 +136,13 @@ class UpdatesManager:
         except Exception as e:
             raise UpdatesManagerError("Failed to build updates table") from e
 
-        # Select only the latest update records into a new table
+        # Select only the latest update records into a new table.
         try:
             self._updates_table.create_latest_only()
         except Exception as e:
             raise UpdatesManagerError("Failed to create latest-only updates table") from e
 
-        # Merge the latest-only updates into the target tables
+        # Merge the latest-only updates into the target tables.
         try:
             self._merge_updates(self._updates_table.latest_only_table_fqn)
         except Exception as e:

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -63,9 +63,9 @@ class UpdatesManager:
 
     Parameters
     ----------
-    config : `PpdbBigQueryConfig`
+    config
         Configuration for the PPDB BigQuery interface.
-    table_name_format : `str`, optional
+    table_name_format
         Optional format string for the target table names used by the mergers.
     """
 
@@ -103,7 +103,7 @@ class UpdatesManager:
 
         Parameters
         ----------
-        replica_chunks: `Sequence` [ `PpdbReplicaChunkExtended` ]
+        replica_chunks
             The replica chunks with the update records.
 
         Raises
@@ -154,7 +154,7 @@ class UpdatesManager:
 
         Parameters
         ----------
-        chunks : `Sequence` [ `PpdbReplicaChunkExtended` ]
+        chunks
             Replica chunks with update_count > 0.
         """
         for chunk in chunks:
@@ -220,7 +220,7 @@ class UpdatesManager:
 
         Parameters
         ----------
-        target_table_fqn : `str`
+        target_table_fqn
             Fully qualified name of the latest-only updates table for the
             merge operation.
         """
@@ -245,9 +245,9 @@ class UpdatesManager:
 
         Parameters
         ----------
-        job : `bigquery.job.QueryJob`
+        job
             The BigQuery job with the statistics to log.
-        target_table_fqn : `str`
+        target_table_fqn
             Fully qualified name of the target table for the merge operation.
         """
         total = job.num_dml_affected_rows

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
@@ -55,7 +55,7 @@ class UpdatesMerger:
     SQL_RESOURCE_NAME: str
     """Base name of the SQL file (without .sql extension) containing the MERGE
     statement for this merger. The SQL file must be located in the
-    `lsst.dax.ppdb.config.sql` package."""
+    ``lsst.dax.ppdb.config.sql`` package."""
 
     def __init__(self, table_name_format: str | None = None) -> None:
         if table_name_format:
@@ -72,7 +72,7 @@ class UpdatesMerger:
         self, *, client: bigquery.Client, updates_table_fqn: str, target_dataset_fqn: str
     ) -> bigquery.QueryJob:
         """Apply updates from the updates table specified by
-        `updates_table_fqn` to the target table in the `target_dataset_fqn`
+        ``updates_table_fqn`` to the target table in the ``target_dataset_fqn``
         dataset.
 
         Parameters
@@ -86,7 +86,7 @@ class UpdatesMerger:
 
         Returns
         -------
-        `google.cloud.bigquery.job.QueryJob`
+        `~google.cloud.bigquery.job.QueryJob`
             The completed BigQuery job.
         """
         sql = SqlResource(

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
@@ -86,7 +86,7 @@ class UpdatesMerger:
 
         Returns
         -------
-        job : `google.cloud.bigquery.job.QueryJob`
+        `google.cloud.bigquery.job.QueryJob`
             The completed BigQuery job.
         """
         sql = SqlResource(

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
@@ -39,7 +39,7 @@ class UpdatesMerger:
 
     Parameters
     ----------
-    table_name_format : `str`, optional
+    table_name_format
         Optional format string for the target table name. The
         class-level ``TABLE_NAME`` will be substituted into ``{}``
         (e.g., ``"_{}_promoted_tmp"`` produces
@@ -77,11 +77,11 @@ class UpdatesMerger:
 
         Parameters
         ----------
-        client : `google.cloud.bigquery.Client`
+        client
             BigQuery client.
-        updates_table_fqn : `str`
+        updates_table_fqn
             Fully-qualified BigQuery table name containing updates.
-        target_dataset_fqn : `str`
+        target_dataset_fqn
             Fully-qualified BigQuery dataset name containing the target table.
 
         Returns

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
@@ -102,7 +102,7 @@ class UpdatesTable:
 
         Returns
         -------
-        `google.cloud.bigquery.Table`
+        `~google.cloud.bigquery.table.Table`
             The created table.
 
         Raises
@@ -156,7 +156,7 @@ class UpdatesTable:
 
         Returns
         -------
-        `google.cloud.bigquery.LoadJob`
+        `~google.cloud.bigquery.job.LoadJob`
             Completed BigQuery load job.
 
         Raises
@@ -166,8 +166,8 @@ class UpdatesTable:
 
         Notes
         -----
-        This uses a batch load via `Client.load_table_from_json` (not streaming
-        inserts). The table must already exist.
+        This uses a batch load via ``Client.load_table_from_json`` (not
+        streaming inserts). The table must already exist.
         """
         rows: list[dict[str, Any]] = [
             {

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
@@ -120,8 +120,8 @@ class UpdatesTable:
         - field_name: STRING (REQUIRED)
         - value_json: JSON (REQUIRED)
         - replica_chunk_id: INT64 (REQUIRED)
-        - update_order: INT64 (NULLABLE)
-        - update_time_ns: INT64 (NULLABLE)
+        - update_order: INT64 (REQUIRED)
+        - update_time_ns: INT64 (REQUIRED)
         """
         schema: list[bigquery.SchemaField] = [
             bigquery.SchemaField("table_name", "STRING", mode="REQUIRED"),

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
@@ -85,7 +85,7 @@ class UpdatesTable:
 
         Returns
         -------
-        id_str : `str`
+        `str`
             The record ID values joined by ``"-"``.
         """
         return "-".join(str(x) for x in record_id)
@@ -102,7 +102,7 @@ class UpdatesTable:
 
         Returns
         -------
-        table : `google.cloud.bigquery.Table`
+        `google.cloud.bigquery.Table`
             The created table.
 
         Raises
@@ -156,7 +156,7 @@ class UpdatesTable:
 
         Returns
         -------
-        load_job : `google.cloud.bigquery.LoadJob`
+        `google.cloud.bigquery.LoadJob`
             Completed BigQuery load job.
 
         Raises

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_table.py
@@ -37,15 +37,15 @@ class UpdatesTable:
 
     Parameters
     ----------
-    client : `google.cloud.bigquery.Client`
+    client
         BigQuery client.
-    project_id : `str`
+    project_id
         Google Cloud project ID.
-    dataset_id : `str`
+    dataset_id
         BigQuery dataset ID.
-    table_name : `str`, optional
+    table_name
         Name of the updates table. Defaults to ``"updates"``.
-    latest_only_table_name : `str`, optional
+    latest_only_table_name
         Name of the latest-only updates table. Defaults to
         ``"updates_latest_only"``.
     """
@@ -80,7 +80,7 @@ class UpdatesTable:
 
         Parameters
         ----------
-        record_id : `Iterable`[`int`]
+        record_id
             The record ID as an iterable of integers.
 
         Returns
@@ -151,7 +151,7 @@ class UpdatesTable:
 
         Parameters
         ----------
-        records : `Iterable` [ `ExpandedUpdateRecord` ]
+        records
             Iterable of update records to insert.
 
         Returns

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -31,7 +31,7 @@ def felis_schema_options(parser: argparse.ArgumentParser) -> None:
 
     Parameters
     ----------
-    parser : `~argparse.ArgumentParser`
+    parser
         The argument parser to which the options are added.
     """
     group = parser.add_argument_group("felis schema options")
@@ -54,7 +54,7 @@ def sql_db_options(parser: argparse.ArgumentParser) -> None:
 
     Parameters
     ----------
-    parser : `~argparse.ArgumentParser`
+    parser
         The argument parser to which the options are added.
     """
     group = parser.add_argument_group("database options")
@@ -92,7 +92,7 @@ def replication_options(parser: argparse.ArgumentParser) -> None:
 
     Parameters
     ----------
-    parser : `~argparse.ArgumentParser`
+    parser
         The argument parser to which the options are added.
     """
     group = parser.add_argument_group("replication options")
@@ -136,7 +136,7 @@ def upload_options(parser: argparse.ArgumentParser) -> None:
 
     Parameters
     ----------
-    parser : `~argparse.ArgumentParser`
+    parser
         The argument parser to which the options are added.
     """
     group = parser.add_argument_group("upload chunk options")
@@ -171,7 +171,7 @@ def bigquery_options(parser: argparse.ArgumentParser) -> None:
 
     Parameters
     ----------
-    parser : `~argparse.ArgumentParser`
+    parser
         The argument parser to which the options are added.
     """
     group = parser.add_argument_group("BigQuery options")

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -53,7 +53,7 @@ class Ppdb(ABC):
 
         Parameters
         ----------
-        config : `PpdbConfig`
+        config
             Configuration object, type of this object determines type of the
             Ppdb implementation.
 
@@ -70,7 +70,7 @@ class Ppdb(ABC):
 
         Parameters
         ----------
-        uri : `~lsst.resources.ResourcePathExpression`
+        uri
             Location of the file containing serialized configuration in YAML
             format.
 
@@ -96,7 +96,7 @@ class Ppdb(ABC):
 
         Parameters
         ----------
-        start_chunk_id : `int`, optional
+        start_chunk_id
             If specified this will be the starting chunk ID to return. If not
             specified then all chunks are returned.
 
@@ -124,19 +124,18 @@ class Ppdb(ABC):
 
         Parameters
         ----------
-        replica_chunk : `~lsst.dax.apdb.ReplicaChunk`
+        replica_chunk
             Insertion ID for APDB data.
-        objects : `~lsst.dax.apdb.ApdbTableData`
+        objects
             Matching APDB data for DiaObjects.
-        sources : `~lsst.dax.apdb.ApdbTableData`
+        sources
             Matching APDB data for DiaSources.
-        forced_sources : `~lsst.dax.apdb.ApdbTableData`
+        forced_sources
             Matching APDB data for DiaForcedSources.
-        update_records : `~collections.abc.Collection` \
-                [`~lsst.dax.apdb.ApdbUpdateRecord`]
+        update_records
             Records of updates to be applied to pre-existing data. The records
             must be in the same order as they were originally applied to APDB.
-        update : `bool`, optional
+        update
             If `True` then allow updates for existing  data from the same
             ``replica_chunk``.
 

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -21,13 +21,17 @@
 
 from __future__ import annotations
 
-__all__ = ["Ppdb"]
+__all__ = ["Ppdb", "PpdbReplicaChunk"]
 
 from abc import ABC, abstractmethod
 from collections.abc import Collection, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import astropy.time
+
+if TYPE_CHECKING:
+    import uuid  # noqa: F401 (needed for autodoc to resolve inherited annotations)
 
 from lsst.dax.apdb import ApdbMetadata, ApdbTableData, ApdbUpdateRecord, ReplicaChunk
 from lsst.resources import ResourcePathExpression
@@ -102,7 +106,8 @@ class Ppdb(ABC):
 
         Returns
         -------
-        `~collections.abc.Sequence` [`PpdbReplicaChunk`] or `None`
+        `~collections.abc.Sequence` [`~lsst.dax.ppdb.PpdbReplicaChunk`] or
+        `None`
             List of chunks, they may be time-ordered if database supports
             ordering. `None` is returned if database is not configured to store
             chunk information.

--- a/python/lsst/dax/ppdb/ppdb.py
+++ b/python/lsst/dax/ppdb/ppdb.py
@@ -59,7 +59,7 @@ class Ppdb(ABC):
 
         Returns
         -------
-        ppdb : `Ppdb`
+        `Ppdb`
             Instance of `Ppdb` class.
         """
         return ppdb_from_config(config)
@@ -76,7 +76,7 @@ class Ppdb(ABC):
 
         Returns
         -------
-        ppdb : `Ppdb`
+        `Ppdb`
             Instance of `Ppdb` class.
         """
         config = PpdbConfig.from_uri(uri)
@@ -102,7 +102,7 @@ class Ppdb(ABC):
 
         Returns
         -------
-        chunks : `~collections.abc.Sequence` [`PpdbReplicaChunk`] or `None`
+        `~collections.abc.Sequence` [`PpdbReplicaChunk`] or `None`
             List of chunks, they may be time-ordered if database supports
             ordering. `None` is returned if database is not configured to store
             chunk information.

--- a/python/lsst/dax/ppdb/ppdb_config.py
+++ b/python/lsst/dax/ppdb/ppdb_config.py
@@ -49,7 +49,7 @@ class PpdbConfig(BaseModel):
 
         Returns
         -------
-        config : `PpdbConfig`
+        `PpdbConfig`
             PPD configuration object.
         """
         path = ResourcePath(uri)

--- a/python/lsst/dax/ppdb/ppdb_config.py
+++ b/python/lsst/dax/ppdb/ppdb_config.py
@@ -43,7 +43,7 @@ class PpdbConfig(BaseModel):
 
         Parameters
         ----------
-        uri : `~lsst.resources.ResourcePathExpression`
+        uri
             Location of the file containing serialized configuration in YAML
             format.
 

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -48,19 +48,19 @@ class Replicator:
 
     Parameters
     ----------
-    apdb : `~lsst.dax.apdb.ApdbReplica`
+    apdb
         Object providing access to APDB replica management.
-    ppdb : `Ppdb`
+    ppdb
         Object providing access to PPD operations.
-    update : `bool`
+    update
         If `True` then allow updates to previously replicated data.
-    min_wait_time : `int`
+    min_wait_time
         Minimum time in seconds to wait for replicating a chunk after a next
         chunk appears.
-    max_wait_time : `int`
+    max_wait_time
         Maximum time in seconds to wait for replicating a chunk if no chunk
         appears.
-    check_interval : `int`
+    check_interval
         Time in seconds to wait before checking for new chunks.
     """
 
@@ -90,11 +90,11 @@ class Replicator:
 
         Parameters
         ----------
-        apdb_chunks : `~collections.abc.Iterable` [`ReplicaChunk`]
+        apdb_chunks
             List of APDB chunks.
-        ppdb_chunks : `~collections.abc.Iterable` [`PpdbReplicaChunk`]
+        ppdb_chunks
             List of PPDB chunks.
-        count : `int`, optional
+        count
             Maximum number of chunks to copy, if not specified then copy all
             chunks that can be copied.
 
@@ -132,9 +132,9 @@ class Replicator:
 
         Parameters
         ----------
-        apdb_chunk : `ReplicaChunk`
+        apdb_chunk
             APDB chunk to copy.
-        more_chunks : `bool`
+        more_chunks
             If True then there are more chunks to copy after this one.
 
         Returns
@@ -195,9 +195,9 @@ class Replicator:
 
         Parameters
         ----------
-        single : `bool`, optional
+        single
             If `True` then copy only one chunk and stop. Default is `False`.
-        exit_on_empty : `bool`, optional
+        exit_on_empty
             If `True` then exit if no chunks are found. Default is `False`.
         """
         wait_time = 0

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -100,7 +100,7 @@ class Replicator:
 
         Returns
         -------
-        `list` [`ReplicaChunk`]
+        `list` [`~lsst.dax.apdb.ReplicaChunk`]
             Chunks that were replicated to PPDB.
         """
         existing_ppdb_ids = {ppdb_chunk.id for ppdb_chunk in ppdb_chunks}

--- a/python/lsst/dax/ppdb/replicator.py
+++ b/python/lsst/dax/ppdb/replicator.py
@@ -100,7 +100,7 @@ class Replicator:
 
         Returns
         -------
-        count : `list` [`ReplicaChunk`]
+        `list` [`ReplicaChunk`]
             Chunks that were replicated to PPDB.
         """
         existing_ppdb_ids = {ppdb_chunk.id for ppdb_chunk in ppdb_chunks}
@@ -139,7 +139,7 @@ class Replicator:
 
         Returns
         -------
-        can_copy : `bool`
+        `bool`
             If True then chunk is OK to copy.
         """
         now = astropy.time.Time.now()

--- a/python/lsst/dax/ppdb/scripts/create_bigquery.py
+++ b/python/lsst/dax/ppdb/scripts/create_bigquery.py
@@ -55,38 +55,38 @@ def create_bigquery(
 
     Parameters
     ----------
-    output_config : `str`
+    output_config
         Name of the new configuration file for created BigQuery PPDB instance.
-    db_url : `str`
+    db_url
         Database URL in SQLAlchemy format for PPDB instance.
-    project_id : `str`
+    project_id
         GCP project ID.
-    dataset_id : `str`
+    dataset_id
         BigQuery dataset name, e.g., 'my_project:my_dataset'.
-    bucket_name : `str`
+    bucket_name
         GCS bucket name to use for Parquet output.
-    object_prefix : `str`
+    object_prefix
         Object prefix to use in GCS bucket for Parquet output.
-    replication_dir : `str`
+    replication_dir
         Directory used for replication staging area.
-    db_drop : `bool`
+    db_drop
         If True then drop existing db tables.
-    db_schema : `str`
+    db_schema
         Database schema name for PPDB instance.
-    felis_path : `str`, optional
+    felis_path
         Path to Felis database. If `None`, defaults to the default path in SDM
         Schemas.
-    felis_schema : `str`, optional
+    felis_schema
         Felis schema name within the YAML file.
-    stage_chunk_topic : `str`
+    stage_chunk_topic
         Pub/Sub topic to use for staging chunks.
-    parq_batch_size : `int`
+    parq_batch_size
         Number of rows to use when batching Parquet output.
-    parq_compression : `str`
+    parq_compression
         Compression codec to use for Parquet output.
-    delete_existing_dirs : `bool`
+    delete_existing_dirs
         If True then delete existing replication staging directories.
-    validate_config : `bool`
+    validate_config
         If `True`, validate the configuration against GCP resources.
     """
     bq_config = PpdbBigQuery.init_bigquery(

--- a/python/lsst/dax/ppdb/scripts/create_bigquery.py
+++ b/python/lsst/dax/ppdb/scripts/create_bigquery.py
@@ -90,14 +90,11 @@ def create_bigquery(
         If `True`, validate the configuration against GCP resources.
     """
     bq_config = PpdbBigQuery.init_bigquery(
-        # SQL db
         db_url=db_url,
         db_schema=db_schema,
         db_drop=db_drop,
-        # Felis
         felis_path=felis_path,
         felis_schema=felis_schema,
-        # BigQuery
         replication_dir=replication_dir,
         delete_existing_dirs=delete_existing_dirs,
         stage_chunk_topic=stage_chunk_topic,
@@ -107,7 +104,6 @@ def create_bigquery(
         object_prefix=object_prefix,
         project_id=project_id,
         dataset_id=dataset_id,
-        # Whether to validate against GCP resources
         validate_config=validate_config,
     )
     _LOG.info("Created BigQuery configuration: %s", bq_config)

--- a/python/lsst/dax/ppdb/scripts/create_sql.py
+++ b/python/lsst/dax/ppdb/scripts/create_sql.py
@@ -43,24 +43,24 @@ def create_sql(
 
     Parameters
     ----------
-    db_url : `str`
+    db_url
         SQLAlchemy connection string.
-    schema : `str` or `None`
+    schema
         Database schema name, `None` to use default schema.
-    output_config : `str`
+    output_config
         Name of the file to write PPDB configuration.
-    felis_path : `str`
+    felis_path
         Path to the Felis YAML file with table schema definition.
-    felis_schema : `str`
+    felis_schema
         Name of the schema defined in felis YAML file.
-    connection_pool : `bool`
+    connection_pool
         If True then enable connection pool.
-    isolation_level : `str` or `None`
+    isolation_level
         Transaction isolation level, if unset then backend-default value is
         used.
-    connection_timeout : `float` or `None`
+    connection_timeout
         Maximum connection timeout in seconds.
-    drop : `bool`
+    drop
         If `True` then drop existing tables.
     """
     config = PpdbSql.init_database(

--- a/python/lsst/dax/ppdb/scripts/replication_list_chunks_apdb.py
+++ b/python/lsst/dax/ppdb/scripts/replication_list_chunks_apdb.py
@@ -31,7 +31,7 @@ def replication_list_chunks_apdb(apdb_config: str) -> None:
 
     Parameters
     ----------
-    apdb_config : `str`
+    apdb_config
         URL for APDB configuration file.
     """
     apdb = ApdbReplica.from_uri(apdb_config)

--- a/python/lsst/dax/ppdb/scripts/replication_list_chunks_ppdb.py
+++ b/python/lsst/dax/ppdb/scripts/replication_list_chunks_ppdb.py
@@ -31,7 +31,7 @@ def replication_list_chunks_ppdb(ppdb_config: str) -> None:
 
     Parameters
     ----------
-    ppdb_config : `str`
+    ppdb_config
         URL for PPDB configuration file.
     """
     ppdb = Ppdb.from_uri(ppdb_config)

--- a/python/lsst/dax/ppdb/scripts/replication_run.py
+++ b/python/lsst/dax/ppdb/scripts/replication_run.py
@@ -47,24 +47,24 @@ def replication_run(
 
     Parameters
     ----------
-    apdb_config : `str`
+    apdb_config
         URL for APDB configuration file.
-    ppdb_config : `str`
+    ppdb_config
         URL for PPDB configuration file.
-    single : `bool`
+    single
         Copy single bucket and stop.
-    update : `bool`
+    update
         If `True` then allow updates to previously replicated data.
-    min_wait_time : `int`
+    min_wait_time
         Minimum time in seconds to wait for replicating a chunk after a next
         chunk appears.
-    max_wait_time : `int`
+    max_wait_time
         Maximum time in seconds to wait for replicating a chunk if no chunk
         appears.
-    check_interval : `int`
+    check_interval
         Time in seconds to wait before next check if there was no replicated
         chunks.
-    exit_on_empty : `bool`
+    exit_on_empty
         If `True` then exit if there are no chunks to replicate, otherwise
         keep waiting for new chunks.
     """

--- a/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
+++ b/python/lsst/dax/ppdb/scripts/upload_chunks_run.py
@@ -38,15 +38,15 @@ def upload_chunks_run(
 
     Parameters
     ----------
-    ppdb_config : `str`
+    ppdb_config
         PPDB configuration URI.
-    wait_interval : `int`
+    wait_interval
         Time in seconds to wait before checking for new chunks to upload.
-    upload_interval : `int`
+    upload_interval
         Time in seconds to wait between uploads of chunks.
-    exit_on_empty : `bool`
+    exit_on_empty
         If `True`, exit the process if there are no chunks to upload.
-    exit_on_error : `bool`
+    exit_on_error
         If `True`, exit the process if there is an error during upload.
     """
     ppdb = PpdbBigQuery.from_uri(ppdb_config)

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql.py
@@ -76,7 +76,7 @@ class PpdbSql(Ppdb, PpdbSqlBase):
 
     Parameters
     ----------
-    config : `PpdbSqlConfig`
+    config
         Configuration object with SQL database parameters.
     """
 
@@ -522,24 +522,24 @@ class PpdbSql(Ppdb, PpdbSqlBase):
 
         Parameters
         ----------
-        db_url : `str`
+        db_url
             SQLAlchemy database connection URI.
-        schema_file : `str` or `None`
+        schema_file
             Name of YAML file with ``Felis`` schema, if `None` then default
             schema file is used.
-        schema_name : `str` or `None`
+        schema_name
             Database schema name, if `None` then default schema is used.
-        felis_schema : `str` or `None`
+        felis_schema
             Name of the schema in YAML file, if `None` then file has to contain
             single schema.
-        use_connection_pool : `bool`
+        use_connection_pool
             If True then allow use of connection pool.
-        isolation_level : `str` or `None`
+        isolation_level
             Transaction isolation level, if unset then backend-default value is
             used.
-        connection_timeout : `float` or `None`
+        connection_timeout
             Maximum connection timeout in seconds.
-        drop : `bool`
+        drop
             If `True` then drop existing tables.
         """
         sa_metadata, schema_version = cls.read_schema(schema_file, schema_name, felis_schema, db_url)

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql.py
@@ -91,11 +91,11 @@ class PpdbSql(Ppdb, PpdbSqlBase):
 
     @property
     def metadata(self) -> ApdbMetadata:
-        # docstring is inherited from a base class
+        # docstring is inherited from a base class.
         return self._metadata
 
     def get_replica_chunks(self, start_chunk_id: int | None = None) -> list[PpdbReplicaChunk] | None:
-        # docstring is inherited from a base class
+        # docstring is inherited from a base class.
         table = self.get_table("PpdbReplicaChunk")
         query = select(
             table.columns["apdb_replica_chunk"],
@@ -111,7 +111,7 @@ class PpdbSql(Ppdb, PpdbSqlBase):
             for row in result:
                 # When we store these timestamps we convert astropy Time to
                 # unix_tai and then to `datetime` in UTC. This conversion
-                # reverses that process,
+                # reverses that process.
                 last_update_time = self.to_astropy_tai(row[1])
                 replica_time = self.to_astropy_tai(row[3])
                 ids.append(
@@ -134,7 +134,7 @@ class PpdbSql(Ppdb, PpdbSqlBase):
         *,
         update: bool = False,
     ) -> None:
-        # docstring is inherited from a base class
+        # docstring is inherited from a base class.
 
         # We want to run all inserts in one transaction.
         with self._engine.begin() as connection:
@@ -291,7 +291,7 @@ class PpdbSql(Ppdb, PpdbSqlBase):
     def _update_objects(
         self, records: list[ApdbUpdateRecord], connection: sqlalchemy.engine.Connection
     ) -> None:
-        # Collect all primary keys
+        # Collect all primary keys.
         ids = set()
         for record in records:
             match record:
@@ -352,7 +352,7 @@ class PpdbSql(Ppdb, PpdbSqlBase):
     def _update_sources(
         self, records: list[ApdbUpdateRecord], connection: sqlalchemy.engine.Connection
     ) -> None:
-        # Collect all primary keys
+        # Collect all primary keys.
         ids = set()
         for record in records:
             match record:

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql.py
@@ -72,7 +72,7 @@ class PpdbSqlConfig(PpdbConfig, PpdbSqlBaseConfig):
 
 
 class PpdbSql(Ppdb, PpdbSqlBase):
-    """Implementation of `Ppdb` using a SQL database.
+    """Implementation of `~lsst.dax.ppdb.Ppdb` using a SQL database.
 
     Parameters
     ----------

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
@@ -64,7 +64,7 @@ class PasswordProvider(ABC):
 
         Returns
         -------
-        password : `str`
+        `str`
             Plain-text password to embed in the database connection URL.
         """
         raise NotImplementedError()
@@ -286,7 +286,7 @@ class PpdbSqlBase:
 
         Returns
         -------
-        key : `str`
+        `str`
             Name of the metadata key for storing the code version.
 
         Raises
@@ -302,7 +302,7 @@ class PpdbSqlBase:
 
         Returns
         -------
-        version : `~lsst.dax.apdb.VersionTuple`
+        `~lsst.dax.apdb.VersionTuple`
             Current version of the code.
 
         Raises
@@ -322,7 +322,7 @@ class PpdbSqlBase:
 
         Returns
         -------
-        value : `str` or `None`
+        `str` or `None`
             Metadata value or `None` if key does not exist.
         """
         version_str = self._metadata.get(version_key)
@@ -537,7 +537,7 @@ class PpdbSqlBase:
 
         Returns
         -------
-        tables : `~collections.abc.Iterable` [ `str` ]
+        `~collections.abc.Iterable` [ `str` ]
             List of tables from ``schema_dict`` on which to filter.
 
         Notes

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
@@ -75,7 +75,7 @@ class MissingSchemaVersionError(RuntimeError):
 
     Parameters
     ----------
-    schema_name : `str`
+    schema_name
         Name of the schema with missing version.
     """
 
@@ -127,7 +127,7 @@ class PpdbSqlBase:
 
     Parameters
     ----------
-    config : `PpdbSqlBaseConfig`
+    config
         Configuration object.
 
     Notes
@@ -186,9 +186,9 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        config : `PpdbSqlBaseConfig`
+        config
             Configuration object with SQL parameters.
-        password_provider : `PasswordProvider`, optional
+        password_provider
             If provided, the password returned by
             ``password_provider.get_password()`` is injected into the
             database URL.  The URL must not already contain a password when
@@ -226,13 +226,13 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        config : `PpdbSqlBaseConfig`
+        config
             Configuration object with SQL parameters.
-        sa_metadata : `sqlalchemy.schema.MetaData`
+        sa_metadata
             Schema definition.
-        schema_version : `lsst.dax.apdb.VersionTuple`
+        schema_version
             Schema version defined in schema or `None` if not defined.
-        drop : `bool`
+        drop
             If `True` then drop existing tables before creating new ones.
         """
         if config.schema_name is not None:
@@ -270,11 +270,11 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        metadata : `ApdbMetadataSql`
+        metadata
             Metadata table object.
-        key : `str` or `None`
+        key
             Metadata key.
-        value : `str` or `None`
+        value
             Metadata value.
         """
         _LOG.info("store metadata %s = %s", key, value)
@@ -317,7 +317,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        key : `str`
+        key
             Metadata key.
 
         Returns
@@ -336,7 +336,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        expected_version : `lsst.dax.apdb.VersionTuple`
+        expected_version
             Expected schema version.
 
         Raises
@@ -379,15 +379,15 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        schema_file : `str` or `None`
+        schema_file
             Name of YAML file with ``felis`` schema, if `None` then default
             schema file is used.
-        schema_name : `str` or `None`
+        schema_name
             Database schema name, if `None` then default schema is used.
-        felis_schema : `str`, optional
+        felis_schema
             Name of the schema in YAML file, if `None` then file has to contain
             single schema.
-        db_url : `str`
+        db_url
             Database URL.
 
         Returns
@@ -453,7 +453,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        table_name : `str` or `None`
+        table_name
             Name of the table to create. If not provided, defaults to
             "PpdbReplicaChunk".
         """
@@ -512,7 +512,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        name : `str`
+        name
             Name of the table to get.
         """
         for table in self._sa_metadata.tables.values():
@@ -532,7 +532,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        original_table_names : `~collections.abc.Iterable` [ `str` ]
+        original_table_names
             List of table names from the schema on which is filter.
 
         Returns
@@ -553,7 +553,7 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        obj : `Any`
+        obj
             The object to convert, expected to be a `datetime` in UTC.
             The type signature is generic to match astropy's typing.
         """
@@ -571,13 +571,13 @@ class PpdbSqlBase:
 
         Parameters
         ----------
-        connection : `sqlalchemy.engine.Connection`
+        connection
             Active database connection.
-        table : `sqlalchemy.schema.Table`
+        table
             Table object for the replica chunk table.
-        row : `dict` [ `str`, `Any` ]
+        row
             Dictionary of column values to insert or update.
-        key_column_name : `str`
+        key_column_name
             Name of the column to use as the key for the UPSERT operation.
 
         Raises

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
@@ -117,7 +117,7 @@ class PpdbSqlBaseConfig(BaseModel):
 def _onSqlite3Connect(
     dbapiConnection: sqlite3.Connection, connectionRecord: sqlalchemy.pool._ConnectionRecord
 ) -> None:
-    # Enable foreign keys
+    # Enable foreign keys.
     with closing(dbapiConnection.cursor()) as cursor:
         cursor.execute("PRAGMA foreign_keys=ON;")
 

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
@@ -522,7 +522,9 @@ class PpdbSqlBase:
 
     @property
     def schema_version(self) -> VersionTuple:
-        """Version of the APDB database schema (`VersionTuple`)."""
+        """Version of the APDB database schema
+        (`~lsst.dax.apdb.VersionTuple`).
+        """
         return self._schema_version
 
     @classmethod

--- a/python/lsst/dax/ppdb/sql/bulk_insert.py
+++ b/python/lsst/dax/ppdb/sql/bulk_insert.py
@@ -60,7 +60,7 @@ class BulkInserter(ABC):
 
         Returns
         -------
-        count : `int`
+        `int`
             Total number of rows inserted.
         """
         raise NotImplementedError()

--- a/python/lsst/dax/ppdb/sql/bulk_insert.py
+++ b/python/lsst/dax/ppdb/sql/bulk_insert.py
@@ -51,11 +51,11 @@ class BulkInserter(ABC):
 
         Parameters
         ----------
-        table : `sqlalchemy.schema.Table`
+        table
             Table to insert data into.
-        data : `ApdbTableData`
+        data
             Data to insert into the table.
-        chunk_size : `int`, optional
+        chunk_size
             Number of rows for a single chunk for insertion.
 
         Returns
@@ -144,7 +144,7 @@ def make_inserter(connection: sqlalchemy.engine.Connection) -> BulkInserter:
 
     Parameters
     ----------
-    connection : `~sqlalchemy.engine.Connection`
+    connection
         Active database connection.
     """
     if connection.dialect.driver == "psycopg2":

--- a/python/lsst/dax/ppdb/sql/pg_dump.py
+++ b/python/lsst/dax/ppdb/sql/pg_dump.py
@@ -55,9 +55,9 @@ class PgBinaryDumper:
 
     Parameters
     ----------
-    stream : `BinaryIO`
+    stream
         Target binary data stream.
-    table : `sqlalchemy.schema.Table`
+    table
         Table object defining the table structure.
     """
 
@@ -72,7 +72,7 @@ class PgBinaryDumper:
 
         Parameters
         ----------
-        data : `ApdbTableData`
+        data
             Table data to dump.
         """
         # Only care about columns that exists in both table and data.

--- a/python/lsst/dax/ppdb/sql/pg_dump.py
+++ b/python/lsst/dax/ppdb/sql/pg_dump.py
@@ -96,7 +96,7 @@ class PgBinaryDumper:
             for idx, handler in zip(column_indices, handlers, strict=True):
                 struct_data = handler.to_struct(row[idx])
                 if struct_data.value is None:
-                    # Null is encoded as size=-1, without data
+                    # Null is encoded as size=-1, without data.
                     fmt.append("i")
                     args.append(-1)
                 else:
@@ -136,7 +136,7 @@ class _StringColumnDataHandler(_ColumnDataHandler):
     def to_struct(self, column_value: Any) -> StructData:
         if column_value is None:
             return StructData(size=-1, format=self._format, value=None)
-        # Assume that utf8 is OK for all string data
+        # Assume that utf8 is OK for all string data.
         assert isinstance(column_value, str), "Expect string instance"
         value = column_value.encode()
         format = f"{len(value)}{self._format}"

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -83,7 +83,7 @@ def delete_test_bucket(bucket_or_bucket_name: str | storage.Bucket) -> None:
 
     Parameters
     ----------
-    bucket_or_bucket_name: `str` or `storage.Bucket`
+    bucket_or_bucket_name
         The name of the bucket or the actual bucket to delete.
     """
     storage_client = storage.Client()

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -206,7 +206,7 @@ def have_valid_google_credentials() -> bool:
 
     Returns
     -------
-    credentials_valid: `bool`
+    `bool`
         True if valid Google credentials are available, False if not.
 
     Raises

--- a/python/lsst/dax/ppdb/tests/_ppdb.py
+++ b/python/lsst/dax/ppdb/tests/_ppdb.py
@@ -175,7 +175,7 @@ class PpdbTest(unittest.TestCase, ABC):
 
         Parameters
         ----------
-        **kwargs : `Any`
+        **kwargs
             Instance-specific parameters for the PPDB database.
         """
         raise NotImplementedError()
@@ -187,7 +187,7 @@ class PpdbTest(unittest.TestCase, ABC):
 
         Parameters
         ----------
-        **kwargs : `Any`
+        **kwargs
             Instance-specific parameters for the APDB.
         """
         raise NotImplementedError()

--- a/python/lsst/dax/ppdb/tests/_updates.py
+++ b/python/lsst/dax/ppdb/tests/_updates.py
@@ -37,11 +37,11 @@ def _create_test_update_records() -> UpdateRecords:
     """Create test UpdateRecords with sample ApdbUpdateRecord instances."""
     records: list[ApdbUpdateRecord] = []
 
-    # Hardcoded test values
+    # Hardcode time values.
     test_update_time_ns = 1640995200000000000  # 2022-01-01 00:00:00 UTC in nanoseconds
     test_mjd_tai = 59580.0  # Corresponding MJD TAI for 2022-01-01
 
-    # Reassign DIASource to different DIAObject
+    # Reassign DIASource to different DIAObject.
     records.append(
         ApdbReassignDiaSourceToDiaObjectRecord(
             update_time_ns=test_update_time_ns,
@@ -54,7 +54,7 @@ def _create_test_update_records() -> UpdateRecords:
         )
     )
 
-    # Reassign DIASource to SSObject
+    # Reassign DIASource to SSObject.
     records.append(
         ApdbReassignDiaSourceToSSObjectRecord(
             update_time_ns=test_update_time_ns,
@@ -68,7 +68,7 @@ def _create_test_update_records() -> UpdateRecords:
         )
     )
 
-    # Withdraw DIASource
+    # Withdraw DIASource.
     records.append(
         ApdbWithdrawDiaSourceRecord(
             update_time_ns=test_update_time_ns,
@@ -81,7 +81,7 @@ def _create_test_update_records() -> UpdateRecords:
         )
     )
 
-    # Withdraw DIAForcedSource
+    # Withdraw DIAForcedSource.
     records.append(
         ApdbWithdrawDiaForcedSourceRecord(
             update_time_ns=test_update_time_ns,
@@ -96,7 +96,7 @@ def _create_test_update_records() -> UpdateRecords:
         )
     )
 
-    # Close DIAObject validity interval
+    # Close DIAObject validity interval.
     records.append(
         ApdbCloseDiaObjectValidityRecord(
             update_time_ns=test_update_time_ns,
@@ -109,7 +109,7 @@ def _create_test_update_records() -> UpdateRecords:
         )
     )
 
-    # Update DIAObject nDiaSources count
+    # Update DIAObject nDiaSources count.
     records.append(
         ApdbUpdateNDiaSourcesRecord(
             update_time_ns=test_update_time_ns,

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -62,14 +62,14 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         )
         replicator.run(exit_on_empty=True)
 
-        # Create a unique test bucket name and set up GCS resources
+        # Create a unique test bucket name and set up GCS resources.
         self.ppdb_config.bucket_name = generate_test_bucket_name("ppdb-test-gcs-upload")
         self._storage_client = storage.Client()
         self._bucket = self._storage_client.bucket(self.ppdb_config.bucket_name)
         self._bucket.create(location="US")
 
     def tearDown(self):
-        # Delete the test GCS bucket
+        # Delete the test GCS bucket.
         delete_test_bucket(self._bucket)
         super().tearDown()
 
@@ -77,7 +77,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         """Test that the update records are correctly uploaded to Google Cloud
         Storage after replication.
         """
-        # Configure and run the uploader
+        # Configure and run the uploader.
         uploader = ChunkUploaderWithoutPubSub(
             self.ppdb,
             wait_interval=0,
@@ -87,7 +87,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         print(f"Uploader will copy files to {uploader.config.bucket_name}/{uploader.config.object_prefix}/")
         uploader.run()
 
-        # Retrieve the update records file
+        # Retrieve the update records file.
         blobs = list(self._bucket.list_blobs(match_glob="**/update_records.parquet"))
         update_records_files = [b.name for b in blobs]
         self.assertEqual(
@@ -97,7 +97,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
             f"{len(update_records_files)}: {update_records_files}",
         )
 
-        # Download the parquet file and deserialize the update records
+        # Download the parquet file and deserialize the update records.
         update_records_bytes = blobs[0].download_as_bytes()
         update_records = UpdateRecords.from_parquet_bytes(update_records_bytes)
         self.assertEqual(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -44,7 +44,7 @@ class ManifestTestCase(unittest.TestCase):
         )
         self.assertTrue(manifest.is_empty_chunk())
 
-        # A manifest with update_count > 0 should not be empty
+        # A manifest with update_count > 0 should not be empty.
         manifest_with_updates = Manifest(
             replica_chunk_id="12345",
             unique_id="550e8400-e29b-41d4-a716-446655440000",

--- a/tests/test_ppdb_sql.py
+++ b/tests/test_ppdb_sql.py
@@ -115,7 +115,7 @@ class ApdbPostgresTestCase(PpdbTest, unittest.TestCase):
 class ApdbPostgresNamespaceTestCase(ApdbPostgresTestCase):
     """A test case for ApdbSql class using Postgres backend with schema name"""
 
-    # use mixed case to trigger quoting
+    # Use mixed case to trigger quoting.
     schema_name = "test_schema001"
 
     def make_instance(self, **kwargs: Any) -> PpdbConfig:

--- a/tests/test_update_record_expander.py
+++ b/tests/test_update_record_expander.py
@@ -40,11 +40,11 @@ class UpdateRecordExpanderTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        # Test time for consistent timestamps
+        # Define fixed update times.
         self.update_time = astropy.time.Time("2021-03-01T12:00:00", format="isot", scale="tai")
         self.update_time_ns = int(self.update_time.unix_tai * 1e9)
 
-        # Test replica chunk ID
+        # Define a dummy replica chunk ID to use in tests.
         self.replica_chunk_id = 12345
 
     def test_reassign_diasource_to_diaobject(self) -> None:
@@ -215,7 +215,7 @@ class UpdateRecordExpanderTestCase(unittest.TestCase):
         expanded_record = expanded[0]
         self.assertEqual(expanded_record.table_name, "DiaForcedSource")
         # The record ID should be a list of the composite key components
-        # [diaObjectId, visit, detector] for BigQuery compatibility
+        # [diaObjectId, visit, detector] for BigQuery compatibility.
         expected_record_id = (200001, 12345, 42)
         self.assertEqual(expanded_record.record_id, expected_record_id)
         self.assertEqual(expanded_record.field_name, "timeWithdrawnMjdTai")
@@ -228,7 +228,7 @@ class UpdateRecordExpanderTestCase(unittest.TestCase):
 
         self.assertEqual(len(expanded), 10)
 
-        # Verify that all expanded records have correct the replica_chunk_id
+        # Verify that all expanded records have correct the replica_chunk_id.
         for record in expanded:
             self.assertEqual(record.replica_chunk_id, self.replica_chunk_id)
 

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -53,7 +53,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        # Set up BigQuery client and test dataset
+        # Set up BigQuery client and test dataset.
         self.bq_client = bigquery.Client()
 
         bucket_name = generate_test_bucket_name("ppdb-updates-manager-test")
@@ -69,14 +69,14 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             "project_id": project_id,
         }
 
-        # Setup the Postgres database and create the config instance
+        # Setup the Postgres database and create the config instance.
         self.ppdb_config = self.make_instance(config)
 
-        # Create the test dataset and tables in BigQuery
+        # Create the test dataset and tables in BigQuery.
         self.target_dataset_fqn = f"{project_id}.{dataset_id}"
         self._create_test_dataset(self.bq_client, dataset_id)
 
-        # Create the test GCS bucket
+        # Create the test GCS bucket.
         storage_client = storage.Client()
         try:
             bucket = storage_client.bucket(self.ppdb_config.bucket_name)
@@ -84,12 +84,12 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         except Exception as e:
             self.fail(f"Failed to create test GCS bucket: {e}")
 
-        # Create the PPDB instance
+        # Create the PPDB instance.
         self.ppdb = Ppdb.from_config(self.ppdb_config)
         assert isinstance(self.ppdb, PpdbBigQuery)
 
     def tearDown(self):
-        # Delete the test dataset
+        # Delete the test dataset.
         try:
             self.bq_client.delete_dataset(
                 self.ppdb_config.dataset_id, delete_contents=True, not_found_ok=True
@@ -97,7 +97,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         except Exception as e:
             print(f"Failed to delete test dataset: {e}")
 
-        # Delete the test GCS bucket
+        # Delete the test GCS bucket.
         storage_client = storage.Client()
         try:
             bucket = storage_client.bucket(self.ppdb_config.bucket_name)
@@ -114,7 +114,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         dataset = bigquery.Dataset(f"{client.project}.{dataset_id}")
         client.create_dataset(dataset, exists_ok=False)
 
-        # Create DiaObject table
+        # Create DiaObject table.
         schema = [
             bigquery.SchemaField("diaObjectId", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("validityEndMjdTai", "FLOAT", mode="NULLABLE"),
@@ -136,7 +136,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         )
         job.result()
 
-        # Create test DiaSource table
+        # Create test DiaSource table.
         schema = [
             bigquery.SchemaField("diaSourceId", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("diaObjectId", "INTEGER", mode="NULLABLE"),
@@ -184,7 +184,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         )
         job.result()
 
-        # Create test DiaForcedSource table
+        # Create test DiaForcedSource table.
         schema = [
             bigquery.SchemaField("diaObjectId", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("visit", "INTEGER", mode="REQUIRED"),
@@ -220,7 +220,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             def rows(self) -> Collection[tuple]:
                 return []
 
-        # Create and store the test update records
+        # Create and store the test update records.
         update_records = _create_test_update_records()
         test_replica_chunk_id = 12345
         self.ppdb.store(
@@ -236,7 +236,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             update=True,
         )
 
-        # Configure and run the uploader without publishing to Pub/Sub
+        # Configure and run the uploader without publishing to Pub/Sub.
         uploader = ChunkUploaderWithoutPubSub(
             self.ppdb,
             wait_interval=0,
@@ -245,7 +245,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         )
         uploader.run()
 
-        # Apply the updates to the target tables using the UpdatesManager
+        # Apply the updates to the target tables using the UpdatesManager.
         updates_manager = UpdatesManager(self.ppdb.config)
         replica_chunks = self.ppdb.get_replica_chunks_ext_by_ids([test_replica_chunk_id])
         updates_manager.apply_updates(replica_chunks)

--- a/tests/test_updates_table.py
+++ b/tests/test_updates_table.py
@@ -35,31 +35,33 @@ class TestUpdatesTable(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test fixtures."""
-        # Create BigQuery client
+        # Create BigQuery client.
         self.client = bigquery.Client()
 
-        # Create unique dataset name for this test run
+        # Create unique dataset name for this test run.
         self.dataset_id = f"test_updates_{uuid.uuid4().hex[:8]}"
         self.project_id = self.client.project
         self.table_name = "updates"
         self.table_fqn = f"{self.project_id}.{self.dataset_id}.{self.table_name}"
 
-        # Create the test dataset
+        # Create the test dataset.
         dataset = bigquery.Dataset(f"{self.project_id}.{self.dataset_id}")
-        # Set a short expiration for cleanup safety (1 hour)
-        dataset.default_table_expiration_ms = 3600000  # 1 hour
+
+        # Set a short expiration on the dataset for cleanup safety (1 hour).
+        dataset.default_table_expiration_ms = 3600000
+
         self.dataset = self.client.create_dataset(dataset)
 
-        # Create UpdatesTable instance
+        # Create UpdatesTable instance.
         self.updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
 
     def tearDown(self) -> None:
         """Clean up test fixtures."""
-        # Always clean up the test dataset, whether test passed or failed
+        # Always clean up the test dataset, whether test passed or failed.
         try:
             self.client.delete_dataset(self.dataset_id, delete_contents=True, not_found_ok=True)
         except Exception:
-            # If deletion fails, at least the expiration will clean it up
+            # If deletion fails, at least the expiration will clean it up.
             pass
 
     def test_table_fqn_property(self) -> None:
@@ -70,11 +72,11 @@ class TestUpdatesTable(unittest.TestCase):
         """Test creation of the updates table."""
         table = self.updates_table.create()
 
-        # Verify table was created successfully
+        # Verify table was created successfully.
         self.assertEqual(table.table_id, self.table_name)
         self.assertEqual(table.dataset_id, self.dataset_id)
 
-        # Verify schema is correct
+        # Verify schema is correct.
         expected_fields = {
             "table_name": ("STRING", "REQUIRED"),
             "record_id": ("INTEGER", "REPEATED"),
@@ -91,14 +93,14 @@ class TestUpdatesTable(unittest.TestCase):
 
     def test_create_table_already_exists(self) -> None:
         """Test creating a table that already exists raises an error."""
-        # Create table first time - should succeed
+        # Create table first time - should succeed.
         self.updates_table.create()
 
-        # Try to create again - should raise Conflict
+        # Try to create again - should raise Conflict.
         with self.assertRaises(Exception) as cm:
             self.updates_table.create()
 
-        # Check that it's a conflict-type error
+        # Check that it's a conflict-type error.
         self.assertIn("already exists", str(cm.exception).lower())
 
     def test_insert_records(self) -> None:
@@ -106,17 +108,17 @@ class TestUpdatesTable(unittest.TestCase):
         # Create the table first
         self.updates_table.create()
 
-        # Get test update records and expand them
+        # Get test update records and expand them.
         update_records = _create_test_update_records()
         expanded_records = UpdateRecordExpander.expand_updates(update_records, 12345)
 
-        # Insert the records
+        # Insert the records.
         job = self.updates_table.insert(expanded_records)
 
-        # Verify the job completed successfully
+        # Verify the job completed successfully.
         self.assertIsNone(job.errors)
 
-        # Verify records were inserted by querying the table
+        # Verify records were inserted by querying the table.
         query = f"SELECT COUNT(*) as count FROM `{self.table_fqn}`"
         result = list(self.client.query(query).result())
         record_count = result[0].count
@@ -159,13 +161,13 @@ class TestUpdatesTable(unittest.TestCase):
         # Create the table first
         self.updates_table.create()
 
-        # Insert empty list
+        # Insert empty list.
         job = self.updates_table.insert([])
 
-        # Verify the job completed successfully
+        # Verify the job completed successfully.
         self.assertIsNone(job.errors)
 
-        # Verify no records were inserted
+        # Verify no records were inserted.
         query = f"SELECT COUNT(*) as count FROM `{self.table_fqn}`"
         result = list(self.client.query(query).result())
         record_count = result[0].count
@@ -173,31 +175,31 @@ class TestUpdatesTable(unittest.TestCase):
 
     def test_latest_updates_only(self) -> None:
         """Test functionality for getting only the latest updates."""
-        # Create the source table
+        # Create the source table.
         self.updates_table.create()
 
-        # Get test records and expand them
+        # Get test records and expand them.
         update_records = _create_test_update_records()
         expanded_records = UpdateRecordExpander.expand_updates(update_records, 0)
 
-        # Insert all of the records into the updates table
+        # Insert all of the records into the updates table.
         self.updates_table.insert(expanded_records)
 
-        # Count the original records
+        # Count the original records.
         query = f"SELECT COUNT(*) as count FROM `{self.table_fqn}`"
         original_count = list(self.client.query(query).result())[0].count
 
-        # Create table with only the latest updates
+        # Create table with only the latest updates.
         self.updates_table.create_latest_only()
 
-        # Count the new number of records
+        # Count the new number of records.
         query = f"SELECT COUNT(*) as count FROM `{self.updates_table.latest_only_table_fqn}`"
         latest_only_count = list(self.client.query(query).result())[0].count
 
         # There should be fewer records now.
         self.assertLess(latest_only_count, original_count)
 
-        # Verify specific record has the later update value
+        # Verify specific record has the later update value.
         record_key = UpdatesTable._make_record_key([100001])
         query = f"""
         SELECT value_json


### PR DESCRIPTION
This PR fixes a number of issues with the project's documentation and Sphinx site, plus makes some minor changes to the linting configuration. Please see the [Jira ticket](https://rubinobs.atlassian.net/browse/DM-54653) for a complete list of changes. Many warnings were fixed so that the documentation site now builds cleanly with `-W` turned on alongside `-n` when running `package-docs` in CI.

**Notes**

There is a [known issue](https://github.com/googleapis/google-cloud-python/issues/15968) with generated links for the `google` intersphinx projects being incorrect, but I would still like to include them for link checking. The problem may be fixed eventually. (This repository does not contain user-facing code, so it should not be a major issue if the links are broken. And the doc site is not even being deployed, currently.)