### PR TITLE
DM-54664: Deploy the lsst.io site

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -52,3 +52,19 @@ jobs:
       - name: Build documentation
         working-directory: ./doc
         run: package-docs build -n -W
+
+      # Only attempt documentation uploads for tagged releases and pull
+      # requests from ticket branches in the same repository.  This avoids
+      # version clutter in the docs and failures when a PR doesn't have access
+      # to secrets.
+      - name: Upload to LSST the Docs
+        uses: lsst-sqre/ltd-upload@v1
+        with:
+          project: "dax-ppdb"
+          dir: "doc/_build/html"
+          username: ${{ secrets.LTD_USERNAME }}
+          password: ${{ secrets.LTD_PASSWORD }}
+        if: >
+          github.event_name != 'merge_group'
+          && (github.event_name != 'pull_request'
+              || startsWith(github.head_ref, 'tickets/'))

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -8,3 +8,4 @@ doxygen.conf
 # Sphinx products
 _build
 py-api
+dev/internals

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -6,3 +6,8 @@ https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
 from documenteer.conf.guide import *
+
+autodoc_pydantic_model_show_config_summary = False
+autodoc_pydantic_settings_show_config_summary = False
+autodoc_pydantic_settings_show_json = False
+autodoc_pydantic_model_show_json = False

--- a/doc/dev/internals.rst
+++ b/doc/dev/internals.rst
@@ -5,25 +5,25 @@ Python API reference
 ####################
 
 .. automodapi:: lsst.dax.ppdb
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:
 
 .. automodapi:: lsst.dax.ppdb.bigquery
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:
 
 .. automodapi:: lsst.dax.ppdb.bigquery.updates
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:
 
 .. automodapi:: lsst.dax.ppdb.cli
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:
 
 .. automodapi:: lsst.dax.ppdb.scripts
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:
 
 .. automodapi:: lsst.dax.ppdb.sql
-   :no-main-docstr:
+   :include-all-objects:
    :no-inheritance-diagram:

--- a/doc/dev/internals.rst
+++ b/doc/dev/internals.rst
@@ -1,0 +1,29 @@
+:og:description: "Developer documentation for the DAX PPDB package."
+
+####################
+Python API reference
+####################
+
+.. automodapi:: lsst.dax.ppdb
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.bigquery
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.bigquery.updates
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.cli
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.scripts
+   :no-main-docstr:
+   :no-inheritance-diagram:
+
+.. automodapi:: lsst.dax.ppdb.sql
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/doc/documenteer.toml
+++ b/doc/documenteer.toml
@@ -7,6 +7,17 @@ package = "lsst-dax-ppdb"
 [build]
 clean = true
 
+[sphinx]
+disable_primary_sidebars = [
+    "index",
+    "dev/internals",
+]
+extensions = [
+    "sphinxcontrib.autodoc_pydantic",
+]
+nitpicky = true
+python_api_dir = "dev/internals"
+
 [sphinx.intersphinx.projects]
 astropy = "https://docs.astropy.org/en/stable"
 python = "https://docs.python.org/3"

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,10 +9,8 @@ the PPDB. Implementations are provided for PostgreSQL and BigQuery databases.
 DAX PPDB is developed on GitHub at https://github.com/lsst/dax_ppdb and is
 available on `PyPI <https://pypi.org/>`__ as ``lsst-dax-ppdb``.
 
-Python API
-==========
-
-.. toctree:
+.. toctree::
    :maxdepth: 2
+   :hidden:
 
    dev/internals

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,71 +1,18 @@
-.. py:currentmodule:: lsst.dax.ppdb
+:html_theme.sidebar_secondary.remove:
 
-.. _lsst.dax.ppdb:
+DAX PPDB
+========
 
-#############
-lsst.dax.ppdb
-#############
+DAX PPDB provides Python tools for replication of APDB data and ingestion into
+the PPDB. Implementations are provided for PostgreSQL and BigQuery databases.
 
-.. Paragraph that describes what this Python module does and links to related modules and frameworks.
+DAX PPDB is developed on GitHub at https://github.com/lsst/dax_ppdb and is
+available on `PyPI <https://pypi.org/>`__ as ``lsst-dax-ppdb``.
 
-.. .. _lsst.dax.ppdb-using:
+Python API
+==========
 
-.. Using lsst.dax.ppdb
-.. ===================
+.. toctree:
+   :maxdepth: 2
 
-.. toctree linking to topics related to using the module's APIs.
-
-.. .. toctree::
-..    :maxdepth: 1
-
-.. _lsst.dax.ppdb-contributing:
-
-Contributing
-============
-
-``lsst.dax.ppdb`` is developed at https://github.com/lsst/dax_ppdb.
-You can find Jira issues for this module under the `dax_ppdb <https://jira.lsstcorp.org/issues/?jql=project%20%3D%20DM%20AND%20component%20%3D%20dax_ppdb>`_ component.
-
-.. If there are topics related to developing this module (rather than using it), link to this from a toctree placed here.
-
-.. .. toctree::
-..    :maxdepth: 1
-
-.. .. _lsst.dax.ppdb-scripts:
-
-.. Script reference
-.. ================
-
-.. .. TODO: Add an item to this toctree for each script reference topic in the scripts subdirectory.
-
-.. .. toctree::
-..    :maxdepth: 1
-
-.. .. _lsst.dax.ppdb-pyapi:
-
-Python API reference
-====================
-
-.. automodapi:: lsst.dax.ppdb
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: lsst.dax.ppdb.bigquery
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: lsst.dax.ppdb.bigquery.updates
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: lsst.dax.ppdb.cli
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: lsst.dax.ppdb.scripts
-   :no-main-docstr:
-   :no-inheritance-diagram:
-
-.. automodapi:: lsst.dax.ppdb.sql
-   :no-main-docstr:
-   :no-inheritance-diagram:
+   dev/internals

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -61,7 +61,7 @@ class Manifest(BaseModel):
 
     unique_id: UUID
     """Globally unique opaque identifier for the export operation or replica
-    (`UUID`).
+    (`uuid.UUID`).
     """
 
     schema_version: str
@@ -77,7 +77,7 @@ class Manifest(BaseModel):
 
     table_data: dict[str, TableStats]
     """Mapping of table name to per-table statistics
-    (`dict`[`str`,`TableStats`])."""
+    (`dict` [`str`, `TableStats`])."""
 
     compression_format: str
     """Name of the compression format used for artifacts (e.g., "gzip",

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -101,7 +101,7 @@ class PpdbBigQueryConfig(PpdbConfig):
     """
 
     sql: PpdbSqlBaseConfig
-    """SQL database configuration (`PpdbSqlBaseConfig`)."""
+    """SQL database configuration (`~lsst.dax.ppdb.sql.PpdbSqlBaseConfig`)."""
 
     @property
     def replication_path(self) -> Path:

--- a/python/lsst/dax/ppdb/ppdb_config.py
+++ b/python/lsst/dax/ppdb/ppdb_config.py
@@ -49,7 +49,7 @@ class PpdbConfig(BaseModel):
 
         Returns
         -------
-        `PpdbConfig`
+        `~lsst.dax.ppdb.PpdbConfig`
             PPD configuration object.
         """
         path = ResourcePath(uri)


### PR DESCRIPTION
This PR adds configuration to CI for deploying the site to https://dax-ppdb.lsst.io.

The site configuration in `doc` was updated, and the existing layout was rearranged as well.

See https://dax-ppdb.lsst.io/v/DM-54664/index.html for site preview including these changes.