### PR TITLE
DM-50641: Fill validityEndMjdTai in DiaObject during promotion

### DIFF
--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -37,6 +37,7 @@ from lsst.dax.apdb import ApdbTables
 from .ppdb_bigquery import PpdbBigQuery, PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .query_runner import QueryRunner
+from .sql_resource import SqlResource
 from .table_refs import TableRefs
 from .updates.updates_manager import UpdatesManager
 
@@ -137,6 +138,9 @@ class ChunkPromoter:
             # Copy prod tables to temp tables and insert staged data.
             self._copy_to_promoted_tmp()
 
+            # Fill in validityEndMjdTai for DiaObjects in the temp table.
+            self._fill_diaobject_validity_end()
+
             # Apply record updates to the temp tables.
             self._apply_record_updates()
 
@@ -211,6 +215,39 @@ class ChunkPromoter:
         # entirely if there are no updates, so we don't need to check that
         # here.
         updates_manager.apply_updates(self.promotable_chunks)
+
+    def _fill_diaobject_validity_end(self) -> None:
+        """Fill null ``validityEndMjdTai`` values for promoted DiaObject
+        records.
+        """
+        job_name = "fill_diaobject_validity_end"
+
+        target_table = self._table_refs.promoted_tmp_format.format(ApdbTables.DiaObject.value)
+        target_table_fqn = f"{self.config.dataset_id}.{target_table}"
+
+        staging_table = self._table_refs.staging_format.format(ApdbTables.DiaObject.value)
+        staging_table_fqn = f"{self.config.dataset_id}.{staging_table}"
+
+        sql = SqlResource(
+            job_name,
+            format_args={
+                "target_table": target_table_fqn,
+                "staging_table": staging_table_fqn,
+            },
+        ).sql
+        job = self._runner.run_job(job_name, sql)
+
+        # Log the number of number of rows updated.
+        dml_stats = job.dml_stats
+        if dml_stats:
+            updated = dml_stats.updated_row_count
+            logging.info(
+                "Finished job '%s' with %d rows updated",
+                job_name,
+                updated,
+            )
+        else:
+            logging.warning("Finished job '%s' but DML stats are not available", job_name)
 
     def _promote_tmp_to_prod(self) -> None:
         """Swap each prod table with its corresponding *_promoted_tmp by

--- a/python/lsst/dax/ppdb/resources/config/sql/fill_diaobject_validity_end.sql
+++ b/python/lsst/dax/ppdb/resources/config/sql/fill_diaobject_validity_end.sql
@@ -1,0 +1,40 @@
+-- This SQL script fills in null validityEndMjTai values for DiaObject rows
+-- in the target table, which will typically be the "promoted_tmp" version
+-- containing the existing data plus updates from staging. It uses a MERGE
+-- statement to update the target table in place.
+MERGE `{target_table}` AS T
+USING (
+-- Select relevant fields from the target table along with the computed end
+-- time from the window function.
+  SELECT
+    diaObjectId,
+    validityStartMjdTai,
+    computedValidityEndMjdTai
+  FROM (
+-- Use a window function to compute the next validityStartMjdTai for each
+-- DiaObject, which will become the validityEndMjdTai for the current row.
+    SELECT
+      T.diaObjectId,
+      T.validityStartMjdTai,
+      T.validityEndMjdTai,
+      LEAD(T.validityStartMjdTai) OVER (
+        PARTITION BY T.diaObjectId
+        ORDER BY T.validityStartMjdTai
+      ) AS computedValidityEndMjdTai
+    FROM `{target_table}` AS T
+    WHERE T.diaObjectId IN (
+-- Only consider DiaObjects that are present in the staging table, since those
+-- are the ones being updated. This avoids scanning the entire target table.
+      SELECT DISTINCT diaObjectId
+      FROM `{staging_table}`
+    )
+  )
+-- Only include rows where validityEndMjdTai is still NULL and where a non-NULL
+-- end time was computed.
+  WHERE validityEndMjdTai IS NULL AND computedValidityEndMjdTai IS NOT NULL
+) AS S
+-- Match on the full composite key to uniquely identify the row to update.
+ON T.diaObjectId = S.diaObjectId
+  AND T.validityStartMjdTai = S.validityStartMjdTai
+-- Update matching rows by setting validityEndMjdTai to the computed value.
+WHEN MATCHED THEN UPDATE SET validityEndMjdTai = S.computedValidityEndMjdTai;

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -37,6 +37,7 @@ from lsst.dax.ppdb.bigquery import (
     PpdbReplicaChunkExtended,
     TableRefs,
 )
+from lsst.dax.ppdb.bigquery.sql_resource import SqlResource
 from lsst.dax.ppdb.bigquery.updates import ExpandedUpdateRecord, UpdateRecordExpander, UpdateRecords
 from lsst.dax.ppdb.replicator import Replicator
 from lsst.dax.ppdb.tests import fill_apdb
@@ -327,6 +328,219 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         promoter = ChunkPromoter(self.ppdb)
         with self.assertRaises(NoPromotableChunksError):
             promoter.promote_chunks([])
+
+
+@unittest.skipIf(not have_valid_google_credentials(), "Missing valid Google credentials")
+class FillValidityEndTestCase(unittest.TestCase):
+    """Test the fill_diaobject_validity_end SQL MERGE logic in isolation.
+
+    Creates minimal BigQuery tables with controlled DiaObject data and
+    verifies that validityEndMjdTai is filled correctly across various
+    scenarios.
+    """
+
+    def setUp(self):
+        self.bq_client = bigquery.Client()
+        self.project_id = self.bq_client.project
+        self.dataset_id = f"test_fill_validity_end_{uuid.uuid4().hex[:8]}"
+        self.dataset_fqn = f"{self.project_id}.{self.dataset_id}"
+
+        # Create the dataset.
+        dataset = bigquery.Dataset(self.dataset_fqn)
+        self.bq_client.create_dataset(dataset, exists_ok=False)
+
+        # Table FQNs matching the format used by ChunkPromoter.
+        self.target_table = f"{self.dataset_id}._DiaObject_promoted_tmp"
+        self.staging_table = f"{self.dataset_id}._DiaObject_staging"
+        self.target_fqn = f"{self.project_id}.{self.target_table}"
+        self.staging_fqn = f"{self.project_id}.{self.staging_table}"
+
+        # Create target table (promoted_tmp).
+        self.bq_client.query(
+            f"""
+            CREATE TABLE `{self.target_fqn}` (
+                diaObjectId INT64,
+                validityStartMjdTai FLOAT64,
+                validityEndMjdTai FLOAT64
+            )
+            """
+        ).result()
+
+        # Create staging table.
+        self.bq_client.query(
+            f"""
+            CREATE TABLE `{self.staging_fqn}` (
+                diaObjectId INT64,
+                validityStartMjdTai FLOAT64,
+                validityEndMjdTai FLOAT64,
+                apdb_replica_chunk INT64
+            )
+            """
+        ).result()
+
+    def tearDown(self):
+        self.bq_client.delete_dataset(self.dataset_id, delete_contents=True, not_found_ok=True)
+
+    def _insert_target_rows(self, rows: list[tuple]) -> None:
+        """Insert rows into the target table.
+
+        Each row is (diaObjectId, validityStartMjdTai, validityEndMjdTai).
+        """
+        if not rows:
+            return
+        values = ", ".join(f"({r[0]}, {r[1]}, {'NULL' if r[2] is None else r[2]})" for r in rows)
+        self.bq_client.query(
+            f"INSERT INTO `{self.target_fqn}` (diaObjectId, validityStartMjdTai, validityEndMjdTai) "
+            f"VALUES {values}"
+        ).result()
+
+    def _insert_staging_rows(self, rows: list[tuple]) -> None:
+        """Insert rows into the staging table.
+
+        Each row is (diaObjectId, validityStartMjdTai, validityEndMjdTai,
+        apdb_replica_chunk).
+        """
+        if not rows:
+            return
+        values = ", ".join(f"({r[0]}, {r[1]}, {'NULL' if r[2] is None else r[2]}, {r[3]})" for r in rows)
+        self.bq_client.query(
+            f"INSERT INTO `{self.staging_fqn}` "
+            f"(diaObjectId, validityStartMjdTai, validityEndMjdTai, apdb_replica_chunk) "
+            f"VALUES {values}"
+        ).result()
+
+    def _run_fill(self) -> None:
+        """Execute the fill_diaobject_validity_end SQL."""
+        sql = SqlResource(
+            "fill_diaobject_validity_end",
+            format_args={
+                "target_table": self.target_table,
+                "staging_table": self.staging_table,
+            },
+        ).sql
+        self.bq_client.query(sql).result()
+
+    def _get_target_rows(self) -> list[dict]:
+        """Query target table rows sorted by
+        (diaObjectId, validityStartMjdTai).
+        """
+        rows = self.bq_client.query(
+            f"SELECT diaObjectId, validityStartMjdTai, validityEndMjdTai "
+            f"FROM `{self.target_fqn}` ORDER BY diaObjectId, validityStartMjdTai"
+        ).result()
+        return [dict(row) for row in rows]
+
+    def test_noop_all_end_times_set(self) -> None:
+        """No rows are updated when all validityEndMjdTai values are already
+        set.
+        """
+        self._insert_target_rows(
+            [
+                (1, 1.0, 2.0),
+                (1, 2.0, 3.0),
+                (1, 3.0, 4.0),
+            ]
+        )
+        self._insert_staging_rows([(1, 3.0, None, 100)])
+        self._run_fill()
+
+        rows = self._get_target_rows()
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0]["validityEndMjdTai"], 2.0)
+        self.assertEqual(rows[1]["validityEndMjdTai"], 3.0)
+        self.assertEqual(rows[2]["validityEndMjdTai"], 4.0)
+
+    def test_base_case_fills_chain(self) -> None:
+        """NULL validityEndMjdTai values are filled from the next version's
+        start time. The last version stays NULL (no successor).
+        """
+        self._insert_target_rows(
+            [
+                (1, 1.0, None),
+                (1, 2.0, None),
+                (1, 3.0, None),
+            ]
+        )
+        self._insert_staging_rows([(1, 3.0, None, 100)])
+        self._run_fill()
+
+        rows = self._get_target_rows()
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[0]["validityEndMjdTai"], 2.0)
+        self.assertEqual(rows[1]["validityEndMjdTai"], 3.0)
+        self.assertIsNone(rows[2]["validityEndMjdTai"])
+
+    def test_gaps_preserves_existing(self) -> None:
+        """Already-set validityEndMjdTai values are preserved even when they
+        differ from what LEAD() would compute.
+        """
+        self._insert_target_rows(
+            [
+                (1, 1.0, None),
+                (1, 2.0, 2.5),  # Explicitly set to 2.5, not 3.0
+                (1, 3.0, None),
+                (1, 4.0, 4.5),  # Explicitly set to 4.5
+            ]
+        )
+        self._insert_staging_rows([(1, 3.0, None, 100)])
+        self._run_fill()
+
+        rows = self._get_target_rows()
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(rows[0]["validityEndMjdTai"], 2.0)  # Filled: LEAD gives 2.0
+        self.assertEqual(rows[1]["validityEndMjdTai"], 2.5)  # Preserved
+        self.assertEqual(rows[2]["validityEndMjdTai"], 4.0)  # Filled: LEAD gives 4.0
+        self.assertEqual(rows[3]["validityEndMjdTai"], 4.5)  # Preserved
+
+    def test_multiple_objects_independent(self) -> None:
+        """Multiple diaObjectIds are filled independently (PARTITION BY)."""
+        self._insert_target_rows(
+            [
+                (1, 1.0, None),
+                (1, 2.0, None),
+                (2, 10.0, None),
+                (2, 20.0, None),
+            ]
+        )
+        self._insert_staging_rows(
+            [
+                (1, 2.0, None, 100),
+                (2, 20.0, None, 100),
+            ]
+        )
+        self._run_fill()
+
+        rows = self._get_target_rows()
+        self.assertEqual(len(rows), 4)
+        # Object 1
+        self.assertEqual(rows[0]["validityEndMjdTai"], 2.0)
+        self.assertIsNone(rows[1]["validityEndMjdTai"])
+        # Object 2
+        self.assertEqual(rows[2]["validityEndMjdTai"], 20.0)
+        self.assertIsNone(rows[3]["validityEndMjdTai"])
+
+    def test_staging_filter_only_touches_staged_objects(self) -> None:
+        """Only DiaObjects present in the staging table are updated."""
+        self._insert_target_rows(
+            [
+                (1, 1.0, None),
+                (1, 2.0, None),
+                (2, 10.0, None),
+                (2, 20.0, None),
+            ]
+        )
+        # Only object 1 is in staging.
+        self._insert_staging_rows([(1, 2.0, None, 100)])
+        self._run_fill()
+
+        rows = self._get_target_rows()
+        self.assertEqual(len(rows), 4)
+        # Object 1: filled
+        self.assertEqual(rows[0]["validityEndMjdTai"], 2.0)
+        self.assertIsNone(rows[1]["validityEndMjdTai"])
+        # Object 2: untouched
+        self.assertIsNone(rows[2]["validityEndMjdTai"])
+        self.assertIsNone(rows[3]["validityEndMjdTai"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This updates the promotion process to set the `validityEndMjdTai` values from the `validityStartMjdTai` of the next `DiaObject` record, leaving the latest version with an open validity interval. The primary logic is implemented in a SQL script which implements this using a `LEAD` window function. Only rows with a `diaObjectId` in the staging data will be processed in this way to avoid a full table scan on the entire `DiaObject` table. But the operation has to be performed on the prod + staging "promotion temp" table in order to compute the complete validity intervals for the target objects, which may include records not in staging. The PPDB will be completely rebuilt using this new logic, so no backfilling should be required.

This update has been tested in the `ppdb-dev` environment where it was observed that the validity intervals were correctly closed for sets of records having the same `diaObjectId`, with the last one being left open. It was also confirmed that including an update record in the test data to close one of the validity intervals still worked properly.