### PR TITLE
DM-49220: Add command line tool for creating BigQuery dataset objects from a Felis schema

### DIFF
--- a/python/lsst/dax/ppdb/_factory.py
+++ b/python/lsst/dax/ppdb/_factory.py
@@ -79,7 +79,8 @@ def ppdb_from_config(config: PpdbConfig) -> Ppdb:
     TypeError
         Raised if ``config`` is not of a known type.
     """
-    from .bigquery import PpdbBigQuery, PpdbBigQueryConfig
+    from .bigquery import PpdbBigQuery
+    from .bigquery.ppdb_bigquery_config import PpdbBigQueryConfig
     from .sql import PpdbSql, PpdbSqlConfig
 
     # Instantiate appropriate subclass of Ppdb based on type of config object.

--- a/python/lsst/dax/ppdb/bigquery/__init__.py
+++ b/python/lsst/dax/ppdb/bigquery/__init__.py
@@ -23,6 +23,7 @@ from .chunk_promoter import *
 from .chunk_uploader import *
 from .manifest import *
 from .ppdb_bigquery import *
+from .ppdb_bigquery_config import *
 from .ppdb_replica_chunk_extended import *
 from .query_runner import *
 from .sql_resource import *

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -34,7 +34,8 @@ from google.cloud import bigquery
 
 from lsst.dax.apdb import ApdbTables
 
-from .ppdb_bigquery import PpdbBigQuery, PpdbBigQueryConfig
+from .ppdb_bigquery import PpdbBigQuery
+from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .query_runner import QueryRunner
 from .sql_resource import SqlResource

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -35,7 +35,8 @@ from lsst.dax.ppdbx.gcp.gcs import DeleteError, StorageClient, UploadError
 from lsst.dax.ppdbx.gcp.pubsub import Publisher
 
 from .manifest import Manifest
-from .ppdb_bigquery import PpdbBigQuery, PpdbBigQueryConfig
+from .ppdb_bigquery import PpdbBigQuery
+from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .updates.update_records import UpdateRecords
 

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["ConfigValidationError", "PpdbBigQuery", "PpdbBigQueryConfig"]
+__all__ = ["ConfigValidationError", "PpdbBigQuery"]
 
 import datetime
 import logging
@@ -49,9 +49,9 @@ from lsst.dax.apdb.timer import Timer
 
 from .._arrow import write_parquet
 from ..ppdb import Ppdb, PpdbReplicaChunk
-from ..ppdb_config import PpdbConfig
 from ..sql import PasswordProvider, PpdbSqlBase, PpdbSqlBaseConfig
 from .manifest import Manifest, TableStats
+from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .updates.update_records import UpdateRecords
 
@@ -64,53 +64,6 @@ VERSION = VersionTuple(0, 1, 0)
 """Version for the code defined in this module. This needs to be updated
 (following compatibility rules) when schema produced by this code changes.
 """
-
-
-class PpdbBigQueryConfig(PpdbConfig):
-    """Configuration for BigQuery-based PPDB."""
-
-    project_id: str
-    """Google Cloud project ID."""
-
-    dataset_id: str
-    """Target BigQuery dataset ID, without the project."""
-
-    bucket_name: str
-    """Name of Google Cloud Storage bucket for uploading chunks."""
-
-    object_prefix: str
-    """Base prefix for the object in cloud storage."""
-
-    replication_dir: str
-    """Directory where the exported chunks will be stored."""
-
-    stage_chunk_topic: str = "stage-chunk-topic"
-    """Pub/Sub topic name for triggering chunk staging process."""
-
-    parq_batch_size: int = 10000
-    """Number of rows to process in each batch when writing parquet files."""
-
-    parq_compression: str = "snappy"
-    """Compression format for Parquet files."""
-
-    delete_existing_dirs: bool = False
-    """If `True`, existing directories for chunks will be deleted before
-    export. If `False`, an error will be raised if the directory already
-    exists.
-    """
-
-    sql: PpdbSqlBaseConfig
-    """SQL database configuration (`~lsst.dax.ppdb.sql.PpdbSqlBaseConfig`)."""
-
-    @property
-    def replication_path(self) -> Path:
-        """Return path for writing replica chunk data (`pathlib.Path`)."""
-        return Path(self.replication_dir)
-
-    @property
-    def fq_dataset_id(self) -> str:
-        """Fully qualified BigQuery dataset ID, including project (`str`)."""
-        return f"{self.project_id}:{self.dataset_id}"
 
 
 class _SecretManagerPasswordProvider(PasswordProvider):

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -1,4 +1,3 @@
-
 # This file is part of dax_ppdb
 #
 # Developed for the LSST Data Management System.
@@ -20,18 +19,74 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from enum import StrEnum
 from pathlib import Path
+
+from pydantic import BaseModel
 
 from ..ppdb_config import PpdbConfig
 from ..sql import PpdbSqlBaseConfig
 
+__all__ = [
+    "DatasetType",
+    "Datasets",
+    "PpdbBigQueryConfig",
+]
+
+_PPDB_PREFIX = "ppdb"
+
+
+class DatasetType(StrEnum):
+    """Typed keys for BigQuery dataset categories."""
+
+    STAGING = "staging"
+    INTERNAL = "internal"
+    PUBLIC = "public"
+
+
+class Datasets(BaseModel):
+    """Mapping of dataset types to their target names in BigQuery."""
+
+    staging: str = f"{_PPDB_PREFIX}_staging"
+    """Name of the staging dataset used for intermediate storage during
+    replication and promotion processes."""
+
+    internal: str = f"{_PPDB_PREFIX}_internal"
+    """Name of the internal dataset containing the fully replicated and
+    promoted data."""
+
+    public: str = f"{_PPDB_PREFIX}_public"
+    """Name of the public dataset which is presented through the TAP
+    interface."""
+
+    def name_for(self, dataset_type: DatasetType) -> str:
+        """Return the configured dataset name for a dataset type."""
+        match dataset_type:
+            case DatasetType.INTERNAL:
+                return self.internal
+            case DatasetType.PUBLIC:
+                return self.public
+            case DatasetType.STAGING:
+                return self.staging
+
+        # Defensive check in case a bad value was passed at runtime.
+        raise ValueError(f"Unsupported dataset type: {dataset_type!r}")
+
+
+_DEFAULT_FELIS_SCHEMA_URI = "resource://lsst.sdm.schemas/ppdb.yaml"
+"""Default URI for the Felis PPDB schema in SDM Schemas."""
+
+
 class PpdbBigQueryConfig(PpdbConfig):
     """Configuration for BigQuery-based PPDB."""
+
+    felis_schema_uri: str = _DEFAULT_FELIS_SCHEMA_URI
+    """URI for the FELIS schema used in the PPDB."""
 
     project_id: str
     """Google Cloud project ID."""
 
-    dataset_id: str
+    dataset_id: str  # TODO: This should be removed by DM-54681.
     """Target BigQuery dataset ID, without the project."""
 
     bucket_name: str
@@ -61,12 +116,34 @@ class PpdbBigQueryConfig(PpdbConfig):
     sql: PpdbSqlBaseConfig
     """SQL database configuration (`~lsst.dax.ppdb.sql.PpdbSqlBaseConfig`)."""
 
+    datasets: Datasets = Datasets()
+    """Names of the BigQuery datasets used for different purposes
+    (`Datasets`).
+    """
+
     @property
     def replication_path(self) -> Path:
         """Return path for writing replica chunk data (`pathlib.Path`)."""
         return Path(self.replication_dir)
 
+    # TODO: This function should be removed by DM-54681.
     @property
     def fq_dataset_id(self) -> str:
         """Fully qualified BigQuery dataset ID, including project (`str`)."""
         return f"{self.project_id}:{self.dataset_id}"
+
+    def fqn_for(self, dataset_type: DatasetType) -> str:
+        """Return the fully qualified BigQuery dataset name for a dataset type.
+
+        Parameters
+        ----------
+        dataset_type
+            Type of dataset to get the name for.
+
+        Returns
+        -------
+        str
+            Fully qualified BigQuery dataset name (project.dataset).
+        """
+        dataset_name = self.datasets.name_for(dataset_type)
+        return f"{self.project_id}.{dataset_name}"

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -1,0 +1,72 @@
+
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from pathlib import Path
+
+from ..ppdb_config import PpdbConfig
+from ..sql import PpdbSqlBaseConfig
+
+class PpdbBigQueryConfig(PpdbConfig):
+    """Configuration for BigQuery-based PPDB."""
+
+    project_id: str
+    """Google Cloud project ID."""
+
+    dataset_id: str
+    """Target BigQuery dataset ID, without the project."""
+
+    bucket_name: str
+    """Name of Google Cloud Storage bucket for uploading chunks."""
+
+    object_prefix: str
+    """Base prefix for the object in cloud storage."""
+
+    replication_dir: str
+    """Directory where the exported chunks will be stored."""
+
+    stage_chunk_topic: str = "stage-chunk-topic"
+    """Pub/Sub topic name for triggering chunk staging process."""
+
+    parq_batch_size: int = 10000
+    """Number of rows to process in each batch when writing parquet files."""
+
+    parq_compression: str = "snappy"
+    """Compression format for Parquet files."""
+
+    delete_existing_dirs: bool = False
+    """If `True`, existing directories for chunks will be deleted before
+    export. If `False`, an error will be raised if the directory already
+    exists.
+    """
+
+    sql: PpdbSqlBaseConfig
+    """SQL database configuration (`~lsst.dax.ppdb.sql.PpdbSqlBaseConfig`)."""
+
+    @property
+    def replication_path(self) -> Path:
+        """Return path for writing replica chunk data (`pathlib.Path`)."""
+        return Path(self.replication_dir)
+
+    @property
+    def fq_dataset_id(self) -> str:
+        """Fully qualified BigQuery dataset ID, including project (`str`)."""
+        return f"{self.project_id}:{self.dataset_id}"

--- a/python/lsst/dax/ppdb/bigquery/schema/__init__.py
+++ b/python/lsst/dax/ppdb/bigquery/schema/__init__.py
@@ -19,10 +19,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .create_bigquery import create_bigquery
-from .create_datasets import create_datasets
-from .create_sql import create_sql
-from .replication_list_chunks_apdb import replication_list_chunks_apdb
-from .replication_list_chunks_ppdb import replication_list_chunks_ppdb
-from .replication_run import replication_run
-from .upload_chunks_run import upload_chunks_run
+from .dataset_builder import *
+from .felis_converter import *

--- a/python/lsst/dax/ppdb/bigquery/schema/dataset_builder.py
+++ b/python/lsst/dax/ppdb/bigquery/schema/dataset_builder.py
@@ -1,0 +1,578 @@
+# This file is part of dax_ppdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = [
+    "BaseDatasetBuilder",
+    "DatasetBuildManager",
+    "DatasetBuilder",
+    "DatasetBuilderError",
+    "InternalDatasetBuilder",
+    "PublicDatasetBuilder",
+    "SearchIndexDataType",
+    "SearchIndexDefinition",
+    "StagingDatasetBuilder",
+]
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from enum import Enum
+from types import MappingProxyType
+from typing import ClassVar
+
+from felis import Schema
+from google.api_core.exceptions import Conflict
+from google.cloud import bigquery
+from pydantic import BaseModel
+
+from lsst.dax.apdb import ApdbTables
+
+from ..ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
+from .felis_converter import FelisConverter
+
+_LOG = logging.getLogger(__name__)
+
+_DIA_TABLES: tuple[str, ...] = (
+    ApdbTables.DiaObject.value,
+    ApdbTables.DiaSource.value,
+    ApdbTables.DiaForcedSource.value,
+)
+
+
+def _update_schema_fields(table: bigquery.Table, *new_fields: bigquery.SchemaField) -> None:
+    """Add new fields to the schema of a BigQuery table.
+
+    Raises
+    ------
+    ValueError
+        Raised if any of the new fields already exist in the table schema.
+    """
+    existing_field_names = {field.name for field in table.schema}
+    duplicate_field_names = sorted({field.name for field in new_fields if field.name in existing_field_names})
+    if duplicate_field_names:
+        raise ValueError(
+            f"Cannot add fields to table {table.table_id}: "
+            f"the following fields already exist in the schema: {', '.join(duplicate_field_names)}."
+        )
+    schema_fields = list(table.schema)
+    schema_fields.extend(new_fields)
+    table.schema = schema_fields
+
+
+def _geo_point_field() -> bigquery.SchemaField:
+    """Create a BigQuery schema field for an internal geography column used for
+    spatial query optimization.
+    """
+    return bigquery.SchemaField(
+        "geo_point",
+        "GEOGRAPHY",
+        mode="REQUIRED",
+        description="Internal geography column for optimization of spatial queries.",
+    )
+
+
+class DatasetBuilderError(RuntimeError):
+    """Raised when dataset builder operations fail."""
+
+
+class SearchIndexDataType(Enum):
+    """Supported BigQuery search-index data types."""
+
+    STRING = "STRING"
+    INT64 = "INT64"
+    TIMESTAMP = "TIMESTAMP"
+
+
+class SearchIndexDefinition(BaseModel, frozen=True):
+    """Definition for a search index to create."""
+
+    table_name: str
+    """Name of the table on which to create the search index."""
+
+    field_data_types: tuple[tuple[str, SearchIndexDataType], ...]
+    """Tuple of field names and their corresponding data types to include in
+    the search index, e.g., (("field1", SearchIndexDataType.STRING),
+    ("field2", SearchIndexDataType.INT64)).
+    """
+
+    @property
+    def index_name(self) -> str:
+        """The BigQuery search index name for this definition."""
+        index_fields = "_".join(field_name for field_name, _ in self.field_data_types)
+        return f"{self.table_name}_{index_fields}_idx"
+
+
+class DatasetBuilder(ABC):
+    """Build the BigQuery objects for a specific type of dataset.
+
+    Parameters
+    ----------
+    config
+        The PPDB BigQuery configuration containing dataset names and other
+        settings.
+    converter
+        The FelisConverter instance to use for converting Felis schema objects
+        to BigQuery table definitions.
+    """
+
+    dataset_type: ClassVar[DatasetType]
+    """Dataset type this builder handles."""
+
+    def __init__(self, config: PpdbBigQueryConfig, converter: FelisConverter) -> None:
+        self._config = config
+        self._converter = converter
+
+    @abstractmethod
+    def build_tables(self) -> list[bigquery.Table]:
+        """Build BigQuery table objects for a dataset type.
+
+        Returns
+        -------
+        `list` [`google.cloud.bigquery.Table`]
+            BigQuery table objects to create for the dataset.
+        """
+        raise NotImplementedError("build_tables() must be implemented by subclasses of DatasetBuilder.")
+
+    @abstractmethod
+    def build_views(self) -> list[bigquery.Table]:
+        """Build BigQuery views for a dataset type.
+
+        Returns
+        -------
+        `list` [`google.cloud.bigquery.Table`]
+            BigQuery view objects to create for the dataset.
+        """
+        raise NotImplementedError("build_views() must be implemented by subclasses of DatasetBuilder.")
+
+    @abstractmethod
+    def build_search_indexes(self) -> list[SearchIndexDefinition]:
+        """Build search indexes for a dataset type.
+
+        Returns
+        -------
+        list[`SearchIndexDefinition`]
+            Search index definitions to create for the dataset.
+        """
+        raise NotImplementedError(
+            "build_search_indexes() must be implemented by subclasses of DatasetBuilder."
+        )
+
+
+class BaseDatasetBuilder(DatasetBuilder):
+    """Base implementation of DatasetBuilder with no-op optional methods."""
+
+    def build_tables(self) -> list[bigquery.Table]:
+        return []
+
+    def build_views(self) -> list[bigquery.Table]:
+        return []
+
+    def build_search_indexes(self) -> list[SearchIndexDefinition]:
+        return []
+
+
+class StagingDatasetBuilder(BaseDatasetBuilder):
+    """Builder for the staging dataset type."""
+
+    dataset_type = DatasetType.STAGING
+
+    def build_tables(self) -> list[bigquery.Table]:
+        """Create BigQuery tables for the staging dataset type."""
+        # Get the base DIA table definitions.
+        tables = self._converter.convert_tables(
+            _DIA_TABLES,
+            dataset_fqn=self._config.fqn_for(self.dataset_type),
+        )
+
+        # Add the apdb_replica_chunk field to each staging table.
+        for table in tables:
+            apdb_replica_chunk_field = bigquery.SchemaField(
+                "apdb_replica_chunk",
+                "INT64",
+                mode="REQUIRED",
+                description="APDB replica chunk this row belongs to.",
+            )
+            _update_schema_fields(table, apdb_replica_chunk_field)
+
+        return tables
+
+
+class InternalDatasetBuilder(BaseDatasetBuilder):
+    """Builder for the internal dataset type."""
+
+    dataset_type = DatasetType.INTERNAL
+
+    def build_tables(self) -> list[bigquery.Table]:
+        """Create BigQuery tables for the internal dataset type."""
+        # Convert the base DIA tables.
+        tables = self._converter.convert_tables(
+            _DIA_TABLES,
+            dataset_fqn=self._config.fqn_for(self.dataset_type),
+        )
+
+        # Add an internal geography column for spatial query optimization to
+        # each internal table and set clustering on that column.
+        for table in tables:
+            geo_point_field = _geo_point_field()
+            _update_schema_fields(table, geo_point_field)
+            table.clustering_fields = [geo_point_field.name]
+
+        return tables
+
+    def build_search_indexes(self) -> list[SearchIndexDefinition]:
+        return [
+            SearchIndexDefinition(
+                table_name=table_name,
+                field_data_types=(("diaObjectId", SearchIndexDataType.INT64),),
+            )
+            for table_name in _DIA_TABLES
+        ]
+
+
+class PublicDatasetBuilder(BaseDatasetBuilder):
+    """Builder for the public dataset type."""
+
+    dataset_type = DatasetType.PUBLIC
+
+    def _create_explicit_view(self, table_name: str) -> bigquery.Table:
+        """Create an explicit view selecting all columns from the corresponding
+        internal table.
+
+        Parameters
+        ----------
+        table_name
+            Name of the source table and resulting view.
+        """
+        public_dataset_fqn = self._config.fqn_for(self.dataset_type)
+        internal_dataset_fqn = self._config.fqn_for(DatasetType.INTERNAL)
+        column_names = [column.name for column in self._converter.find_table(table_name).columns]
+        column_list = ", ".join(f"`{column_name}`" for column_name in column_names)
+
+        view = bigquery.Table(f"{public_dataset_fqn}.{table_name}")
+        view.view_query = f"SELECT {column_list} FROM `{internal_dataset_fqn}.{table_name}`"
+        return view
+
+    def build_tables(self) -> list[bigquery.Table]:
+        """Create BigQuery tables for the public dataset type.
+
+        Notes
+        -----
+        DiaObject is defined using a table rather than a view, because using
+        ``validityEndMjdTai IS NULL`` as a filter in a plain view definition
+        would be inefficient. A materialized view would be cumbersome, as its
+        references would be invalidated by table swap operations during the
+        promotion process.
+        """
+        (dia_object_table,) = self._converter.convert_tables(
+            [ApdbTables.DiaObject.value],
+            dataset_fqn=self._config.fqn_for(self.dataset_type),
+        )
+
+        # Omit the validityEndMjdTai column from the table definition, as it
+        # will always be null.
+        dia_object_table.schema = [
+            field for field in dia_object_table.schema if field.name != "validityEndMjdTai"
+        ]
+
+        # Add geography column and clustering for spatial query optimization.
+        geo_point_field = _geo_point_field()
+        _update_schema_fields(dia_object_table, geo_point_field)
+        dia_object_table.clustering_fields = [geo_point_field.name]
+
+        return [dia_object_table]
+
+    def build_views(self) -> list[bigquery.Table]:
+        """Create BigQuery views for the public dataset type."""
+        return [
+            self._create_explicit_view(table_name)
+            for table_name in (ApdbTables.DiaSource.value, ApdbTables.DiaForcedSource.value)
+        ]
+
+    def build_search_indexes(self) -> list[SearchIndexDefinition]:
+        """Create search indexes for the public dataset type."""
+        return [
+            SearchIndexDefinition(
+                table_name=ApdbTables.DiaObject.value,
+                field_data_types=(("diaObjectId", SearchIndexDataType.INT64),),
+            )
+        ]
+
+
+class DatasetBuildManager:
+    """Manage dataset builders and dispatch build operations by dataset type.
+
+    Parameters
+    ----------
+    config
+        The PPDB BigQuery configuration containing dataset names and other
+        settings.
+    schema
+        The Felis schema object containing table definitions.
+    exists_ok
+        If True, do not fail if a BigQuery table or view already exists; skip
+        creating it.
+    configure_authorized_views
+        If True, configure internal dataset access entries for public
+        authorized views after build.
+    create_search_indexes
+        If True, create search indexes for each dataset. If False, skip search
+        index creation entirely.
+    """
+
+    _BUILDER_TYPES: Mapping[DatasetType, type[DatasetBuilder]] = MappingProxyType(
+        {
+            StagingDatasetBuilder.dataset_type: StagingDatasetBuilder,
+            InternalDatasetBuilder.dataset_type: InternalDatasetBuilder,
+            PublicDatasetBuilder.dataset_type: PublicDatasetBuilder,
+        }
+    )
+
+    def __init__(
+        self,
+        config: PpdbBigQueryConfig,
+        schema: Schema,
+        exists_ok: bool = False,
+        configure_authorized_views: bool = False,
+        create_search_indexes: bool = True,
+    ) -> None:
+        self._config = config
+        self._schema = schema
+        self._exists_ok = exists_ok
+        self._configure_authorized_views_enabled = configure_authorized_views
+        self._create_search_indexes_enabled = create_search_indexes
+        self._converter = FelisConverter(schema=self._schema)
+
+        # Initialize the builders for all supported dataset types.
+        self._builders: dict[DatasetType, DatasetBuilder] = {
+            dataset_type: builder_type(config=self._config, converter=self._converter)
+            for dataset_type, builder_type in self._BUILDER_TYPES.items()
+        }
+
+        # Initialize the BigQuery client.
+        try:
+            self._client = bigquery.Client(project=self._config.project_id)
+        except Exception as e:
+            raise DatasetBuilderError(f"Failed to initialize BigQuery client: {e}") from e
+
+    def build_datasets(self) -> None:
+        """Create the BigQuery datasets and populate them with the objects
+        produced by the builders.
+
+        Raises
+        ------
+        DatasetBuilderError
+            Raised if any part of the build process fails, including dataset
+            creation, table/view creation, search index creation, or authorized
+            view configuration.
+        """
+        public_views: list[bigquery.Table] = []
+
+        try:
+            # Create the datasets themselves before populating them.
+            self._create_datasets()
+
+            for dataset_type, builder in self._builders.items():
+                # Build the tables for this dataset type and then create them
+                # in BigQuery.
+                tables = builder.build_tables()
+                self._create_resources(
+                    resources=tables,
+                    resource_kind="table",
+                )
+
+                # Build the views for this dataset type and then create them
+                # in BigQuery.
+                views = builder.build_views()
+                self._create_resources(
+                    resources=views,
+                    resource_kind="view",
+                )
+                if dataset_type is DatasetType.PUBLIC:
+                    public_views.extend(views)
+
+                # Build the search index definitions for this dataset type and
+                # then create them in BigQuery.
+                if self._create_search_indexes_enabled:
+                    self._create_search_indexes(builder=builder, dataset_type=dataset_type)
+        except DatasetBuilderError:
+            raise
+        except Exception as e:
+            raise DatasetBuilderError(f"Failed to build datasets: {e}") from e
+
+        # After all datasets are built, optionally configure authorized
+        # view entries for the public views on the internal dataset.
+        try:
+            if self._configure_authorized_views_enabled:
+                self._configure_authorized_views(public_views)
+        except DatasetBuilderError:
+            raise
+        except Exception as e:
+            raise DatasetBuilderError(f"Failed to configure authorized views: {e}") from e
+
+    def _create_datasets(self) -> None:
+        """Create the BigQuery datasets for all supported dataset types.
+
+        Raises
+        ------
+        DatasetBuilderError
+            Raised if a dataset already exists and ``exists_ok`` is not set.
+        """
+        for dataset_type in self._builders:
+            dataset_fqn = self._config.fqn_for(dataset_type)
+
+            _LOG.debug("Creating dataset: %s", dataset_fqn)
+            try:
+                self._client.create_dataset(bigquery.Dataset(dataset_fqn))
+            except Conflict as e:
+                if self._exists_ok:
+                    _LOG.info("Dataset %s already exists and exists_ok=True; skipping.", dataset_fqn)
+                    continue
+                raise DatasetBuilderError(f"Dataset {dataset_fqn!r} already exists.") from e
+            _LOG.debug("Created dataset: %s", dataset_fqn)
+
+    def _create_resources(
+        self,
+        resources: list[bigquery.Table],
+        resource_kind: str,
+    ) -> None:
+        """Create BigQuery resources.
+
+        Parameters
+        ----------
+        resources
+            List of BigQuery table or view objects to create.
+        resource_kind
+            String label for the kind of resource being created, used in log
+            messages.
+        """
+        if not resources:
+            _LOG.debug("No %ss to create", resource_kind)
+            return
+
+        for resource in resources:
+            _LOG.debug("Creating %s: %s", resource_kind, resource.to_api_repr())
+            try:
+                self._client.create_table(resource, exists_ok=self._exists_ok)
+            except Conflict as e:
+                raise DatasetBuilderError(
+                    f"{resource_kind.capitalize()} {resource.table_id!r} already exists."
+                ) from e
+            _LOG.debug("Created %s: %s", resource_kind, resource.table_id)
+
+    def _create_search_indexes(
+        self,
+        builder: DatasetBuilder,
+        dataset_type: DatasetType,
+    ) -> None:
+        """Create search indexes for a dataset type."""
+        dataset_fqn = self._config.fqn_for(dataset_type)
+        for definition in builder.build_search_indexes():
+            field_names = ", ".join(field_name for field_name, _ in definition.field_data_types)
+            data_types = ", ".join(f"'{data_type.value}'" for _, data_type in definition.field_data_types)
+            try:
+                self._client.query(
+                    f"""CREATE SEARCH INDEX {definition.index_name}
+                    ON `{dataset_fqn}.{definition.table_name}`({field_names})
+                    OPTIONS (data_types = [{data_types}]);
+                    """
+                ).result()  # Wait for the operation to complete.
+            except Conflict as e:
+                if self._exists_ok:
+                    _LOG.info(
+                        "Search index already exists for %s and exists_ok=True; skipping.",
+                        dataset_type.value,
+                    )
+                    continue
+                raise DatasetBuilderError("Search index already exists.") from e
+
+    def _configure_authorized_views(self, public_views: list[bigquery.Table]) -> None:
+        """Configure authorized view access entries on the internal dataset for
+        the public views.
+
+        Parameters
+        ----------
+        public_views
+            List of public view objects to configure as authorized views on the
+            internal dataset.
+
+        Notes
+        -----
+        The complexity of this method is due to the fact that we need to
+        preserve any existing entries on the internal dataset which are not
+        managed by this tool, while replacing any existing entries for managed
+        views. The list cannot be appended in place, so we need to build a new,
+        complete list of access entries and then update the dataset with it.
+        """
+        if not public_views:
+            _LOG.warning("No public views found for authorized-view configuration")
+            return
+
+        internal_dataset_fqn = self._config.fqn_for(DatasetType.INTERNAL)
+        internal_dataset = self._client.get_dataset(internal_dataset_fqn)
+
+        # Build a set of public view references managed by this tool.
+        managed_view_refs = {(view.project, view.dataset_id, view.table_id) for view in public_views}
+
+        # Keep any entries that are not managed by this tool.
+        retained_entries: list[bigquery.AccessEntry] = []
+        for entry in internal_dataset.access_entries:
+            # Not a view entry, so keep it.
+            if entry.entity_type != "view":
+                retained_entries.append(entry)
+                continue
+
+            # Get the view reference for this entry.
+            existing_view_ref = (
+                entry.entity_id.get("projectId"),
+                entry.entity_id.get("datasetId"),
+                entry.entity_id.get("tableId"),
+            )
+            # Skip managed views; we'll rebuild them below.
+            if existing_view_ref in managed_view_refs:
+                continue
+            # Keep unrelated/unmanaged views.
+            retained_entries.append(entry)
+
+        # Rebuild managed entries from the current set of public views.
+        managed_view_entries: list[bigquery.AccessEntry] = []
+        for project_id, dataset_id, table_id in sorted(managed_view_refs):
+            managed_view_entries.append(
+                bigquery.AccessEntry(
+                    role=None,
+                    entity_type="view",
+                    entity_id={
+                        "projectId": project_id,
+                        "datasetId": dataset_id,
+                        "tableId": table_id,
+                    },
+                )
+            )
+
+        # Combine the retained and managed entries and update the dataset.
+        internal_dataset.access_entries = retained_entries + managed_view_entries
+        self._client.update_dataset(internal_dataset, ["access_entries"])
+        _LOG.debug(
+            "Configured %d authorized PPDB view entries on dataset %s",
+            len(managed_view_entries),
+            internal_dataset_fqn,
+        )

--- a/python/lsst/dax/ppdb/bigquery/schema/felis_converter.py
+++ b/python/lsst/dax/ppdb/bigquery/schema/felis_converter.py
@@ -1,0 +1,190 @@
+# This file is part of dax_ppdb
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = [
+    "FelisConverter",
+    "FelisConverterError",
+]
+
+from collections.abc import Sequence
+from typing import ClassVar
+
+from felis import Schema
+from felis.datamodel import DataType, Table
+from google.cloud import bigquery
+
+
+class FelisConverterError(RuntimeError):
+    """Raised when Felis to BigQuery conversion fails."""
+
+
+class FelisConverter:
+    """Convert Felis objects to BigQuery.
+
+    Parameters
+    ----------
+    schema
+        Felis schema containing database objects to convert.
+    """
+
+    _TYPE_MAP: ClassVar[dict[DataType, str]] = {
+        DataType.boolean: "BOOL",
+        DataType.byte: "INT64",
+        DataType.short: "INT64",
+        DataType.int: "INT64",
+        DataType.long: "INT64",
+        DataType.float: "FLOAT64",
+        DataType.double: "FLOAT64",
+        DataType.char: "STRING",
+        DataType.string: "STRING",
+        DataType.unicode: "STRING",
+        DataType.text: "STRING",
+        DataType.binary: "BYTES",
+        DataType.timestamp: "TIMESTAMP",
+    }
+
+    def __init__(self, schema: Schema) -> None:
+        self._tables_by_name: dict[str, Table] = {table.name: table for table in schema.tables}
+
+    def find_table(self, name: str) -> Table:
+        """Find a Felis table by name.
+
+        Parameters
+        ----------
+        name
+            Name of the Felis table.
+
+        Returns
+        -------
+        `felis.datamodel.Table`
+            Matching Felis table.
+
+        Raises
+        ------
+        FelisConverterError
+            Raised if the table is not present in the schema.
+        """
+        table = self._tables_by_name.get(name)
+        if table is None:
+            raise FelisConverterError(f"Table {name!r} not found in Felis schema")
+        return table
+
+    def convert_tables(self, names: Sequence[str], dataset_fqn: str) -> list[bigquery.Table]:
+        """Create BigQuery table objects for selected Felis table names.
+
+        Parameters
+        ----------
+        names
+            Sequence of Felis table names to convert.
+        dataset_fqn
+            Fully qualified BigQuery dataset name (project.dataset) used for
+            table references.
+
+        Returns
+        -------
+        list[`google.cloud.bigquery.Table`]
+            Converted BigQuery table objects in the same order as ``names``.
+
+        """
+        return [self._to_bigquery_table(self.find_table(name), dataset_fqn=dataset_fqn) for name in names]
+
+    def _to_bigquery_table(self, table: Table, dataset_fqn: str) -> bigquery.Table:
+        """Convert a Felis table to a BigQuery table object.
+
+        Parameters
+        ----------
+        table
+            Felis table definition.
+        dataset_fqn
+            Fully qualified BigQuery dataset name (project.dataset) used for
+            table references.
+
+        Returns
+        -------
+        `google.cloud.bigquery.Table`
+            BigQuery table object, not yet created remotely.
+
+        Raises
+        ------
+        FelisConverterError
+            Raised if any of the table's columns have unsupported datatypes for
+            conversion.
+        """
+        schema_fields: list[bigquery.SchemaField] = []
+        for column in table.columns:
+            try:
+                field_type = self._to_bigquery_type(column.datatype)
+            except FelisConverterError as e:
+                raise FelisConverterError(
+                    f"Failed to map datatype for {table.name}.{column.name}: {e}"
+                ) from e
+
+            schema_fields.append(
+                bigquery.SchemaField(
+                    name=column.name,
+                    field_type=field_type,
+                    mode=self._to_bigquery_mode(column.nullable),
+                )
+            )
+
+        table_fqn = f"{dataset_fqn}.{table.name}"
+        return bigquery.Table(table_fqn, schema=schema_fields)
+
+    @classmethod
+    def _to_bigquery_type(cls, datatype: DataType) -> str:
+        """Map a Felis datatype to a BigQuery type string.
+
+        Parameters
+        ----------
+        datatype
+            Felis datatype to map.
+
+        Returns
+        -------
+        str
+            Corresponding BigQuery type string.
+
+        Raises
+        ------
+        FelisConverterError
+            Raised if the datatype is not supported for conversion.
+        """
+        if datatype in cls._TYPE_MAP:
+            return cls._TYPE_MAP[datatype]
+        raise FelisConverterError(f"Unsupported Felis type {datatype!r}")
+
+    @staticmethod
+    def _to_bigquery_mode(nullable: bool) -> str:
+        """Return the BigQuery mode string for a nullable column.
+
+        Parameters
+        ----------
+        nullable
+            Whether the column is nullable.
+
+        Returns
+        -------
+        str
+            "NULLABLE" if the column is nullable, otherwise "REQUIRED".
+        """
+        return "NULLABLE" if nullable else "REQUIRED"

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -30,7 +30,7 @@ from collections.abc import Sequence
 
 from google.cloud import bigquery, storage
 
-from ..ppdb_bigquery import PpdbBigQueryConfig
+from ..ppdb_bigquery_config import PpdbBigQueryConfig
 from ..ppdb_replica_chunk_extended import PpdbReplicaChunkExtended
 from .update_record_expander import UpdateRecordExpander
 from .update_records import UpdateRecords

--- a/python/lsst/dax/ppdb/cli/ppdb_cli.py
+++ b/python/lsst/dax/ppdb/cli/ppdb_cli.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 __all__ = ["main"]
 
 import argparse
+from collections.abc import Sequence
 
 from lsst.dax.apdb.cli.logging_cli import LoggingCli
 
@@ -31,16 +32,23 @@ from .. import scripts
 from . import options
 
 
-def main() -> None:
-    """PPDB command line tools."""
+def main(argv: Sequence[str] | None = None) -> None:
+    """PPDB command line tools.
+
+    Parameters
+    ----------
+    argv
+        Command line arguments to parse. If `None`, ``sys.argv[1:]`` is used.
+    """
     parser = argparse.ArgumentParser(description="PPDB command line tools")
     log_cli = LoggingCli(parser)
 
     subparsers = parser.add_subparsers(title="available subcommands", required=True)
     _create_sql_subcommand(subparsers)
     _create_bigquery(subparsers)
+    _create_datasets(subparsers)
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     log_cli.process_args(args)
 
     kwargs = vars(args)
@@ -77,3 +85,30 @@ def _create_bigquery(subparsers: argparse._SubParsersAction) -> None:
     options.felis_schema_options(parser)
     options.bigquery_options(parser)
     parser.set_defaults(method=scripts.create_bigquery)
+
+
+def _create_datasets(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "create-datasets", help="Create one or more BigQuery datasets for the PPDB from a Felis schema file."
+    )
+    parser.add_argument("config", help="URI to the PPDB configuration file.")
+    parser.add_argument(
+        "--exists-ok",
+        help="Do not fail if a BigQuery dataset, table, or view already exists; skip creating it.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--configure-authorized-views",
+        help="Configure internal dataset access entries for public authorized views after build.",
+        default=False,
+        action="store_true",
+    )
+    parser.add_argument(
+        "--disable-search-indexes",
+        help="Skip creating BigQuery search indexes for the datasets.",
+        default=False,
+        action="store_true",
+    )
+
+    parser.set_defaults(method=scripts.create_datasets)

--- a/python/lsst/dax/ppdb/scripts/create_datasets.py
+++ b/python/lsst/dax/ppdb/scripts/create_datasets.py
@@ -1,0 +1,65 @@
+# This file is part of dax_ppdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from felis import Schema
+
+from ..bigquery.ppdb_bigquery_config import PpdbBigQueryConfig
+from ..bigquery.schema import DatasetBuildManager
+from ..ppdb_config import PpdbConfig
+
+
+def create_datasets(
+    config: str,
+    exists_ok: bool = False,
+    configure_authorized_views: bool = False,
+    disable_search_indexes: bool = False,
+) -> None:
+    """Create all BigQuery datasets for the PPDB and populate them with
+    tables and views derived from a Felis schema.
+    """
+    # Load the PPDB config.
+    try:
+        ppdb_config = PpdbConfig.from_uri(config)
+    except Exception as e:
+        raise RuntimeError(f"Failed to load configuration from {config}: {e}") from e
+
+    # Check the config type.
+    if not isinstance(ppdb_config, PpdbBigQueryConfig):
+        raise TypeError(
+            f"Configuration loaded from '{config}' has wrong type, "
+            f"expected PpdbBigQueryConfig, got: {type(ppdb_config)}"
+        )
+
+    # Load the Felis schema from the URI in the config.
+    try:
+        schema = Schema.from_uri(ppdb_config.felis_schema_uri, context={"id_generation": True})
+    except Exception as e:
+        raise RuntimeError(f"Failed to load schema from {ppdb_config.felis_schema_uri}: {e}") from e
+
+    # Build all datasets.
+    build_manager = DatasetBuildManager(
+        ppdb_config,
+        schema,
+        exists_ok=exists_ok,
+        configure_authorized_views=configure_authorized_views,
+        create_search_indexes=not disable_search_indexes,
+    )
+    build_manager.build_datasets()

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -1,3 +1,4 @@
+"""Miscellaneous utilities for BigQuery integration tests."""
 # This file is part of dax_ppdb.
 #
 # Developed for the LSST Data Management System.
@@ -23,6 +24,7 @@ import gc
 import io
 import json
 import logging
+import os
 import shutil
 import tempfile
 import uuid
@@ -46,6 +48,18 @@ try:
     import testing.postgresql
 except ImportError:
     testing = None
+
+__all__ = [
+    "TEST_CONFIG",
+    "ChunkUploaderWithoutPubSub",
+    "PostgresMixin",
+    "SqliteMixin",
+    "delete_test_bucket",
+    "generate_test_bucket_name",
+    "have_valid_google_credentials",
+    "json_rows_to_buf",
+    "search_indexes_enabled",
+]
 
 _LOG = logging.getLogger(__name__)
 
@@ -226,3 +240,11 @@ def have_valid_google_credentials() -> bool:
     credentials.refresh(Request())
 
     return True
+
+
+def search_indexes_enabled() -> bool:
+    """Check if search index creation is enabled for tests."""
+    return os.getenv(
+        "DAX_PPDB_TESTS_SEARCH_INDEXES_ENABLED",
+        "",
+    ).strip().lower() in {"1", "true", "yes", "on"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+# This file is part of dax_ppdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+import uuid
+
+import yaml
+from google.cloud import bigquery
+
+from lsst.dax.ppdb.bigquery.ppdb_bigquery_config import (
+    Datasets,
+    DatasetType,
+    PpdbBigQueryConfig,
+)
+from lsst.dax.ppdb.cli import ppdb_cli
+from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
+from lsst.dax.ppdb.tests._bigquery import (
+    have_valid_google_credentials,
+    search_indexes_enabled,
+)
+
+
+@unittest.skipIf(not have_valid_google_credentials(), "Missing valid Google credentials")
+class CreateDatasetsTestCase(unittest.TestCase):
+    """Integration tests for the ``ppdb-cli create-datasets`` command."""
+
+    def setUp(self) -> None:
+        self.client = bigquery.Client()
+        self.project_id = self.client.project
+
+        # Use unique dataset names so concurrent or repeated test runs do not
+        # collide with one another.
+        suffix = uuid.uuid4().hex[:8]
+        self.datasets = Datasets(
+            internal=f"test_cli_internal_{suffix}",
+            public=f"test_cli_public_{suffix}",
+            staging=f"test_cli_staging_{suffix}",
+        )
+
+        config = PpdbBigQueryConfig(
+            project_id=self.project_id,
+            dataset_id="dummy",  # TODO: This will be removed in DM-54681.
+            bucket_name="test-bucket",
+            object_prefix="data/test",
+            replication_dir="/tmp",
+            sql=PpdbSqlBaseConfig(db_url="sqlite:///:memory:"),
+            datasets=self.datasets,
+        )
+
+        # Serialize the configuration to a YAML file that the CLI can load.
+        self.tempdir = tempfile.mkdtemp()
+        self.config_path = os.path.join(self.tempdir, "ppdb_config.yaml")
+        config_dict = config.model_dump(exclude_unset=True, exclude_defaults=True)
+        config_dict["implementation_type"] = "bigquery"
+        with open(self.config_path, "w") as config_file:
+            yaml.dump(config_dict, config_file)
+
+    def tearDown(self) -> None:
+        for dataset_type in DatasetType:
+            dataset_name = self.datasets.name_for(dataset_type)
+            dataset_fqn = f"{self.project_id}.{dataset_name}"
+            try:
+                self.client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
+            except Exception as e:
+                print(f"Failed to delete {dataset_fqn}: {type(e).__name__}: {e}", file=sys.stderr)
+
+    def test_create_datasets(self) -> None:
+        """Test that ``ppdb-cli create-datasets`` creates the BigQuery
+        datasets described by the configuration file.
+        """
+        argv = ["create-datasets", self.config_path]
+        # Avoid exhausting BigQuery search index creation quotas unless
+        # explicitly enabled for the test run.
+        if not search_indexes_enabled():
+            argv.append("--disable-search-indexes")
+
+        ppdb_cli.main(argv)
+
+        # Verify that the datasets were created in BigQuery with the correct
+        # number of tables.
+        for dataset_type in DatasetType:
+            dataset_name = self.datasets.name_for(dataset_type)
+            self.client.get_dataset(f"{self.project_id}.{dataset_name}")
+            tables = list(self.client.list_tables(f"{self.project_id}.{dataset_name}"))
+            self.assertEqual(len(tables), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -1,0 +1,798 @@
+# This file is part of dax_ppdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import sys
+import unittest
+import uuid
+from unittest.mock import Mock, patch
+
+from felis import Schema
+from google.api_core.exceptions import Conflict
+from google.cloud import bigquery
+
+from lsst.dax.apdb import ApdbTables
+from lsst.dax.ppdb.bigquery.ppdb_bigquery_config import (
+    Datasets,
+    DatasetType,
+    PpdbBigQueryConfig,
+)
+from lsst.dax.ppdb.bigquery.schema.dataset_builder import (
+    BaseDatasetBuilder,
+    DatasetBuilder,
+    DatasetBuilderError,
+    DatasetBuildManager,
+    InternalDatasetBuilder,
+    PublicDatasetBuilder,
+    SearchIndexDataType,
+    SearchIndexDefinition,
+    StagingDatasetBuilder,
+    _update_schema_fields,
+)
+from lsst.dax.ppdb.bigquery.schema.felis_converter import FelisConverter
+from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
+from lsst.dax.ppdb.tests._bigquery import (
+    have_valid_google_credentials,
+    search_indexes_enabled,
+)
+
+# Determine whether search index creation is enabled for tests.
+_SEARCH_INDEXES_ENABLED = search_indexes_enabled()
+
+
+class DatasetBuilderTestMixin:
+    """Shared setup and helpers for dataset builder unit tests."""
+
+    BIGQUERY_CLIENT_PATCH = "lsst.dax.ppdb.bigquery.schema.dataset_builder.bigquery.Client"
+    EXPECTED_TABLES = {"DiaObject", "DiaSource", "DiaForcedSource"}
+    EXPECTED_VIEWS = ["DiaSource", "DiaForcedSource"]
+
+    def setUp(self) -> None:
+        """Test case setup including schema, converter, and standard config
+        with test dataset names.
+        """
+        self.schema = self._load_test_schema()
+        self.converter = FelisConverter(self.schema)
+        self.config = self._make_test_config(
+            project_id="test-project",
+            datasets=Datasets(
+                internal="test_dataset_builder_internal",
+                public="test_dataset_builder_public",
+                staging="test_dataset_builder_staging",
+            ),
+        )
+
+    @staticmethod
+    def _load_test_schema() -> Schema:
+        """Load the test schema from the default URI."""
+        return Schema.from_uri("resource://lsst.sdm.schemas/ppdb.yaml", context={"id_generation": True})
+
+    @staticmethod
+    def _make_test_config(project_id: str, datasets: Datasets) -> PpdbBigQueryConfig:
+        """Create a standard PpdbBigQueryConfig for tests with specified
+        project ID and dataset names.
+        """
+        return PpdbBigQueryConfig(
+            project_id=project_id,
+            dataset_id="test_dataset_builder",
+            bucket_name="test-bucket",
+            object_prefix="data/test",
+            replication_dir="/tmp",
+            sql=PpdbSqlBaseConfig(db_url="sqlite:///:memory:"),
+            datasets=datasets,
+        )
+
+    def _make_public_views(self) -> list[bigquery.Table]:
+        """Create DiaSource and DiaForcedSource views with public FQN."""
+        public_fqn = self.config.fqn_for(DatasetType.PUBLIC)
+        return [
+            bigquery.Table(f"{public_fqn}.{ApdbTables.DiaSource.value}"),
+            bigquery.Table(f"{public_fqn}.{ApdbTables.DiaForcedSource.value}"),
+        ]
+
+    def _inject_mock_client(self, manager: DatasetBuildManager) -> Mock:
+        """Inject a Mock client into manager and return it."""
+        client = Mock()
+        manager._client = client
+        return client
+
+    def _make_mock_builder(self) -> Mock:
+        """Create a DatasetBuilder mock with empty outputs."""
+        builder = Mock(spec=DatasetBuilder)
+        builder.build_tables.return_value = []
+        builder.build_views.return_value = []
+        builder.build_search_indexes.return_value = []
+        return builder
+
+    def _make_builder(self, builder_class: type) -> DatasetBuilder:
+        """Create a builder with standard config/converter."""
+        return builder_class(config=self.config, converter=self.converter)
+
+    def _make_manager(
+        self, exists_ok: bool = False, configure_authorized_views: bool = False
+    ) -> DatasetBuildManager:
+        """Create DatasetBuildManager with the BigQuery client patched out as
+        a Mock.
+        """
+        with patch(self.BIGQUERY_CLIENT_PATCH):
+            return DatasetBuildManager(
+                config=self.config,
+                schema=self.schema,
+                exists_ok=exists_ok,
+                configure_authorized_views=configure_authorized_views,
+            )
+
+    def _make_fqn_table(self, dataset_type: DatasetType, table_name: str) -> bigquery.Table:
+        """Create fully-qualified table reference."""
+        fqn = self.config.fqn_for(dataset_type)
+        return bigquery.Table(f"{fqn}.{table_name}")
+
+
+class BaseDatasetBuilderTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Base dataset builder unit tests."""
+
+    def test_optional_methods_return_empty_lists(self) -> None:
+        """Test that BaseDatasetBuilder optional methods are no-ops."""
+        builder = self._make_builder(BaseDatasetBuilder)
+
+        self.assertEqual(builder.build_tables(), [])
+        self.assertEqual(builder.build_views(), [])
+        self.assertEqual(builder.build_search_indexes(), [])
+
+
+class PublicDatasetBuilderTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Public dataset builder unit tests."""
+
+    def test_creates_diaobject_with_schema_changes(self) -> None:
+        """Test that PublicDatasetBuilder creates DiaObject table without
+        validityEndMjdTai and with geo_point.
+        """
+        builder = self._make_builder(PublicDatasetBuilder)
+
+        tables = builder.build_tables()
+
+        self.assertEqual(len(tables), 1)
+        table = tables[0]
+        self.assertEqual(table.table_id, ApdbTables.DiaObject.value)
+
+        field_names = [field.name for field in table.schema]
+        self.assertIn("diaObjectId", field_names)
+        self.assertNotIn("validityEndMjdTai", field_names)
+        self.assertIn("geo_point", field_names)
+
+        source_table = self.converter.find_table(ApdbTables.DiaObject.value)
+        # We remove validityEndMjdTai and add geo_point, so the count is the
+        # same.
+        self.assertEqual(len(field_names), len(source_table.columns))
+
+    def test_creates_explicit_views(self) -> None:
+        """Test that PublicDatasetBuilder creates explicit views with fully
+        qualified columns and proper FROM clauses.
+        """
+        builder = self._make_builder(PublicDatasetBuilder)
+        public_dataset_fqn = self.config.fqn_for(DatasetType.PUBLIC)
+        internal_dataset_fqn = self.config.fqn_for(DatasetType.INTERNAL)
+
+        views = builder.build_views()
+
+        self.assertEqual([view.table_id for view in views], self.EXPECTED_VIEWS)
+        for view_name, view in zip(self.EXPECTED_VIEWS, views, strict=True):
+            # Views must always have a materialized SQL query.
+            self.assertTrue(view.view_query and view.view_query.strip())
+
+            # Validate that all columns from the source table are included in
+            # the view and that the expected source table is used.
+            table = self.converter.find_table(view_name)
+            column_names = [f"`{column.name}`" for column in table.columns]
+            expected_columns = ", ".join(column_names)
+            expected_query = f"SELECT {expected_columns} FROM `{internal_dataset_fqn}.{view_name}`"
+            self.assertEqual(
+                view.view_query,
+                expected_query,
+            )
+
+            # Ensure each view is created in the public dataset namespace.
+            project, dataset = public_dataset_fqn.split(".", 1)
+            self.assertEqual(view.project, project)
+            self.assertEqual(view.dataset_id, dataset)
+            self.assertEqual(view.table_id, view_name)
+
+    def test_creates_search_index_definitions(self) -> None:
+        """Test that PublicDatasetBuilder creates expected search indexes."""
+        builder = self._make_builder(PublicDatasetBuilder)
+
+        definitions = builder.build_search_indexes()
+
+        self.assertEqual(
+            definitions,
+            [
+                SearchIndexDefinition(
+                    table_name=ApdbTables.DiaObject.value,
+                    field_data_types=(("diaObjectId", SearchIndexDataType.INT64),),
+                )
+            ],
+        )
+
+
+class InternalDatasetBuilderTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Internal dataset builder unit tests."""
+
+    def test_adds_geo_point_and_clustering(self) -> None:
+        """Test that InternalDatasetBuilder adds geo_point GEOGRAPHY field
+        with clustering.
+        """
+        builder = self._make_builder(InternalDatasetBuilder)
+
+        tables = builder.build_tables()
+
+        self.assertEqual({table.table_id for table in tables}, self.EXPECTED_TABLES)
+        for table in tables:
+            geo_point = next(field for field in table.schema if field.name == "geo_point")
+            self.assertEqual(geo_point.field_type, "GEOGRAPHY")
+            self.assertEqual(geo_point.mode, "REQUIRED")
+            self.assertEqual(table.clustering_fields, ["geo_point"])
+
+    def test_creates_search_index_definitions(self) -> None:
+        """Test that InternalDatasetBuilder creates expected search indexes."""
+        builder = InternalDatasetBuilder(config=self.config, converter=self.converter)
+
+        definitions = builder.build_search_indexes()
+
+        self.assertEqual(len(definitions), 3)
+        self.assertEqual(
+            {definition.table_name for definition in definitions},
+            self.EXPECTED_TABLES,
+        )
+        for definition in definitions:
+            self.assertEqual(
+                definition.field_data_types,
+                (("diaObjectId", SearchIndexDataType.INT64),),
+            )
+            self.assertEqual(definition.index_name, f"{definition.table_name}_diaObjectId_idx")
+
+
+class StagingDatasetBuilderTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Staging dataset builder unit tests."""
+
+    def test_adds_replica_chunk(self) -> None:
+        """Test that StagingDatasetBuilder adds apdb_replica_chunk INT64
+        field.
+        """
+        builder = self._make_builder(StagingDatasetBuilder)
+
+        tables = builder.build_tables()
+
+        self.assertEqual({table.table_id for table in tables}, self.EXPECTED_TABLES)
+        for table in tables:
+            chunk_field = next(field for field in table.schema if field.name == "apdb_replica_chunk")
+            self.assertEqual(chunk_field.field_type, "INT64")
+            self.assertEqual(chunk_field.mode, "REQUIRED")
+
+
+class UpdateSchemaFieldsTestCase(unittest.TestCase):
+    """Tests for the _update_schema_fields helper."""
+
+    def _make_table(self) -> bigquery.Table:
+        """Create a table with a single existing field."""
+        table = bigquery.Table("project.dataset.table")
+        table.schema = [bigquery.SchemaField("existing", "INT64")]
+        return table
+
+    def test_adds_new_fields(self) -> None:
+        """Test that new fields are appended to the table schema."""
+        table = self._make_table()
+
+        _update_schema_fields(table, bigquery.SchemaField("added", "STRING"))
+
+        self.assertEqual([field.name for field in table.schema], ["existing", "added"])
+
+    def test_rejects_duplicate_field(self) -> None:
+        """Test that adding an existing field raises and names the
+        duplicate.
+        """
+        table = self._make_table()
+
+        with self.assertRaisesRegex(ValueError, r"already exist in the schema: existing\."):
+            _update_schema_fields(table, bigquery.SchemaField("existing", "INT64"))
+
+    def test_reports_all_duplicate_fields(self) -> None:
+        """Test that every duplicate field name is reported in the message."""
+        table = self._make_table()
+        table.schema = [
+            bigquery.SchemaField("existing", "INT64"),
+            bigquery.SchemaField("other", "INT64"),
+        ]
+
+        with self.assertRaises(ValueError) as cm:
+            _update_schema_fields(
+                table,
+                bigquery.SchemaField("existing", "INT64"),
+                bigquery.SchemaField("other", "INT64"),
+                bigquery.SchemaField("added", "STRING"),
+            )
+
+        message = str(cm.exception)
+        self.assertRegex(message, r"\bexisting\b")
+        self.assertRegex(message, r"\bother\b")
+        self.assertNotRegex(message, r"\badded\b")
+
+
+class SearchIndexTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Search index definition and creation tests."""
+
+    def test_definition_index_name(self) -> None:
+        """Test that SearchIndexDefinition builds the expected index name."""
+        definition = SearchIndexDefinition(
+            table_name=ApdbTables.DiaObject.value,
+            field_data_types=(
+                ("diaObjectId", SearchIndexDataType.INT64),
+                ("insertTime", SearchIndexDataType.TIMESTAMP),
+            ),
+        )
+
+        self.assertEqual(definition.index_name, "DiaObject_diaObjectId_insertTime_idx")
+
+    def test_executes_expected_query(self) -> None:
+        """Test that _create_search_indexes executes expected BigQuery SQL."""
+        manager = self._make_manager()
+
+        definition = SearchIndexDefinition(
+            table_name=ApdbTables.DiaObject.value,
+            field_data_types=(("diaObjectId", SearchIndexDataType.INT64),),
+        )
+        builder = Mock(spec=DatasetBuilder)
+        builder.build_search_indexes.return_value = [definition]
+        query_job = Mock()
+        client = self._inject_mock_client(manager)
+        client.query.return_value = query_job
+
+        manager._create_search_indexes(builder, DatasetType.PUBLIC)
+
+        # Query execution should block until completion.
+        query_job.result.assert_called_once_with()
+        client.query.assert_called_once()
+        sql = client.query.call_args.args[0]
+
+        # Generated SQL should target the expected index, table, and data type.
+        self.assertIn("CREATE SEARCH INDEX DiaObject_diaObjectId_idx", sql)
+        self.assertIn(
+            f"ON `{self.config.fqn_for(DatasetType.PUBLIC)}.{ApdbTables.DiaObject.value}`(diaObjectId)",
+            sql,
+        )
+        self.assertIn("OPTIONS (data_types = ['INT64']);", sql)
+
+    def test_conflict_respects_exists_ok(self) -> None:
+        """Test that _create_search_indexes handles conflicts per exists_ok."""
+        definition = SearchIndexDefinition(
+            table_name=ApdbTables.DiaObject.value,
+            field_data_types=(("diaObjectId", SearchIndexDataType.INT64),),
+        )
+        builder = Mock(spec=DatasetBuilder)
+        builder.build_search_indexes.return_value = [definition]
+
+        manager = self._make_manager()
+
+        query_job = Mock()
+        query_job.result.side_effect = Conflict("already exists")
+        client = self._inject_mock_client(manager)
+        client.query.return_value = query_job
+
+        with self.assertRaisesRegex(DatasetBuilderError, r"Search index already exists"):
+            manager._create_search_indexes(builder, DatasetType.PUBLIC)
+
+        exists_ok_manager = self._make_manager(exists_ok=True)
+
+        exists_ok_client = Mock()
+        exists_ok_query_job = Mock()
+        exists_ok_query_job.result.side_effect = Conflict("already exists")
+        exists_ok_client.query.return_value = exists_ok_query_job
+        exists_ok_manager._client = exists_ok_client
+
+        exists_ok_manager._create_search_indexes(builder, DatasetType.PUBLIC)
+
+
+class DatasetBuildManagerTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Dataset build manager behavior tests."""
+
+    def test_raises_on_client_init_failure(self) -> None:
+        """Test that BigQuery client initialization errors are wrapped in
+        DatasetBuilderError.
+        """
+        with patch(
+            self.BIGQUERY_CLIENT_PATCH,
+            side_effect=RuntimeError("Client initialization failed"),
+        ):
+            with self.assertRaisesRegex(DatasetBuilderError, r"Failed to initialize BigQuery client"):
+                DatasetBuildManager(config=self.config, schema=self.schema)
+
+    def test_create_datasets_creates_each_type(self) -> None:
+        """Test that _create_datasets creates one dataset per dataset type."""
+        manager = self._make_manager()
+        client = self._inject_mock_client(manager)
+
+        manager._create_datasets()
+
+        created_fqns = [
+            f"{call.args[0].project}.{call.args[0].dataset_id}"
+            for call in client.create_dataset.call_args_list
+        ]
+        expected_fqns = [self.config.fqn_for(dataset_type) for dataset_type in DatasetType]
+        self.assertCountEqual(created_fqns, expected_fqns)
+
+    def test_create_datasets_conflict_without_exists_ok_raises(self) -> None:
+        """Test that a dataset Conflict without exists_ok is wrapped as
+        DatasetBuilderError.
+        """
+        manager = self._make_manager()
+        client = self._inject_mock_client(manager)
+        client.create_dataset.side_effect = Conflict("already exists")
+
+        with self.assertRaisesRegex(DatasetBuilderError, r"already exists"):
+            manager._create_datasets()
+
+    def test_create_datasets_conflict_with_exists_ok_continues(self) -> None:
+        """Test that _create_datasets tolerates conflicts when exists_ok."""
+        manager = self._make_manager(exists_ok=True)
+        client = self._inject_mock_client(manager)
+        client.create_dataset.side_effect = Conflict("already exists")
+
+        manager._create_datasets()
+
+        # Creation should be attempted once per dataset type despite conflicts.
+        self.assertEqual(client.create_dataset.call_count, len(DatasetType))
+
+    def test_wraps_conflict_without_exists_ok(self) -> None:
+        """Test that Conflict without exists_ok is wrapped as
+        DatasetBuilderError.
+        """
+        table = bigquery.Table(f"{self.config.project_id}.{self.config.datasets.public}.DiaObject")
+
+        manager = self._make_manager()
+        client = self._inject_mock_client(manager)
+        client.create_table.side_effect = Conflict("already exists")
+        with self.assertRaisesRegex(DatasetBuilderError, r"already exists"):
+            manager._create_resources([table], "table")
+
+    def test_forwards_exists_ok_flag_to_create_table(self) -> None:
+        """Test that exists_ok=True is forwarded to create_table."""
+        table = bigquery.Table(f"{self.config.project_id}.{self.config.datasets.public}.DiaObject")
+
+        exists_ok_manager = self._make_manager(exists_ok=True)
+        exists_ok_client = self._inject_mock_client(exists_ok_manager)
+        exists_ok_manager._create_resources([table], "table")
+        exists_ok_client.create_table.assert_called_once_with(table, exists_ok=True)
+
+    def test_wraps_non_builder_error_from_build_loop(self) -> None:
+        """Test that build_datasets wraps unexpected build-loop failures."""
+        manager = self._make_manager()
+
+        public_builder = Mock(spec=DatasetBuilder)
+        public_builder.build_tables.side_effect = RuntimeError("boom")
+        manager._builders = {DatasetType.PUBLIC: public_builder}
+
+        with self.assertRaisesRegex(DatasetBuilderError, r"Failed to build datasets: boom"):
+            manager.build_datasets()
+
+    def test_authorized_view_error_handling(self) -> None:
+        """Test that build_datasets wraps unexpected errors from authorized
+        view configuration and re-raises DatasetBuilderError unchanged.
+        """
+        public_view = self._make_public_views()[0]
+        public_builder = self._make_mock_builder()
+        public_builder.build_views.return_value = [public_view]
+
+        manager = self._make_manager(
+            configure_authorized_views=True,
+        )
+        manager._builders = {DatasetType.PUBLIC: public_builder}
+
+        # Non-DatasetBuilderError exceptions are wrapped.
+        with patch.object(manager, "_configure_authorized_views", side_effect=RuntimeError("boom")):
+            with self.assertRaisesRegex(DatasetBuilderError, r"Failed to configure authorized views: boom"):
+                manager.build_datasets()
+
+        # DatasetBuilderError is re-raised unchanged.
+        manager2 = self._make_manager(
+            configure_authorized_views=True,
+        )
+        manager2._builders = {DatasetType.PUBLIC: public_builder}
+
+        with patch.object(
+            manager2,
+            "_configure_authorized_views",
+            side_effect=DatasetBuilderError("authorized view failure"),
+        ):
+            with self.assertRaisesRegex(DatasetBuilderError, r"authorized view failure"):
+                manager2.build_datasets()
+
+
+class AuthorizedViewsTestCase(DatasetBuilderTestMixin, unittest.TestCase):
+    """Authorized views configuration tests."""
+
+    def test_preserves_unmanaged_view_permissions(self) -> None:
+        """Test that _configure_authorized_views preserves unmanaged
+        permissions while updating managed entries.
+        """
+        manager = self._make_manager(configure_authorized_views=True)
+
+        # Set up a mix of access entries to test preservation of non-view and
+        # unmanaged view permissions, as well as proper handling of managed
+        # entries.
+        non_view_entry = bigquery.AccessEntry(
+            role="READER",
+            entity_type="userByEmail",
+            entity_id="reader@example.org",
+        )
+        managed_existing_entry = bigquery.AccessEntry(
+            role=None,
+            entity_type="view",
+            entity_id={
+                "projectId": self.config.project_id,
+                "datasetId": self.config.datasets.public,
+                "tableId": ApdbTables.DiaSource.value,
+            },
+        )
+        stale_managed_entry = bigquery.AccessEntry(
+            role=None,
+            entity_type="view",
+            entity_id={
+                "projectId": self.config.project_id,
+                "datasetId": self.config.datasets.public,
+                "tableId": "OldManagedView",
+            },
+        )
+        unrelated_view_entry = bigquery.AccessEntry(
+            role=None,
+            entity_type="view",
+            entity_id={
+                "projectId": "unrelated-project",
+                "datasetId": "unrelated_dataset",
+                "tableId": "UnrelatedView",
+            },
+        )
+
+        dataset = Mock()
+        dataset.access_entries = [
+            non_view_entry,
+            managed_existing_entry,
+            stale_managed_entry,
+            unrelated_view_entry,
+        ]
+
+        client = self._inject_mock_client(manager)
+        client.get_dataset.return_value = dataset
+
+        public_views = [
+            self._make_fqn_table(DatasetType.PUBLIC, ApdbTables.DiaSource.value),
+            self._make_fqn_table(DatasetType.PUBLIC, ApdbTables.DiaForcedSource.value),
+        ]
+
+        manager._configure_authorized_views(public_views)
+
+        # Access entries should be persisted as a single dataset update.
+        client.update_dataset.assert_called_once_with(dataset, ["access_entries"])
+
+        updated_entries = dataset.access_entries
+
+        # Validate the complete managed/unmanaged view reference set.
+        updated_view_refs = {
+            (
+                entry.entity_id["projectId"],
+                entry.entity_id["datasetId"],
+                entry.entity_id["tableId"],
+            )
+            for entry in updated_entries
+            if entry.entity_type == "view" and isinstance(entry.entity_id, dict)
+        }
+        self.assertEqual(
+            updated_view_refs,
+            {
+                (
+                    self.config.project_id,
+                    self.config.datasets.public,
+                    ApdbTables.DiaSource.value,
+                ),
+                (
+                    self.config.project_id,
+                    self.config.datasets.public,
+                    ApdbTables.DiaForcedSource.value,
+                ),
+                (
+                    self.config.project_id,
+                    self.config.datasets.public,
+                    "OldManagedView",
+                ),
+                (
+                    "unrelated-project",
+                    "unrelated_dataset",
+                    "UnrelatedView",
+                ),
+            },
+        )
+
+    def test_skips_api_calls_for_empty_views_list(self) -> None:
+        """Test that _configure_authorized_views skips BigQuery API calls
+        when the views list is empty.
+        """
+        manager = self._make_manager(configure_authorized_views=True)
+        client = self._inject_mock_client(manager)
+        manager._configure_authorized_views([])
+        client.get_dataset.assert_not_called()
+        client.update_dataset.assert_not_called()
+
+
+@unittest.skipIf(not have_valid_google_credentials(), "Missing valid Google credentials")
+class DatasetBuilderBigQueryTestCase(unittest.TestCase):
+    """Integration tests for creating BigQuery tables and views."""
+
+    def _make_integration_manager(self, exists_ok: bool = False) -> DatasetBuildManager:
+        """Create a DatasetBuildManager configured for integration tests."""
+        manager = DatasetBuildManager(
+            config=self.config,
+            schema=self.schema,
+            exists_ok=exists_ok,
+        )
+        if not _SEARCH_INDEXES_ENABLED:
+            for builder in manager._builders.values():
+                builder.build_search_indexes = Mock(return_value=[])
+        return manager
+
+    def _list_search_indexes(self, dataset_name: str) -> list[tuple[str, str]]:
+        """List search indexes as (table_name, index_name) pairs."""
+        query = (
+            f"SELECT table_name, index_name "
+            f"FROM `{self.project_id}.{dataset_name}.INFORMATION_SCHEMA.SEARCH_INDEXES`"
+        )
+        rows = self.client.query(query).result()
+        return [(row.table_name, row.index_name) for row in rows]
+
+    def setUp(self) -> None:
+        self.schema = DatasetBuilderTestMixin._load_test_schema()
+        self.client = bigquery.Client()
+        self.project_id = self.client.project
+
+        # Create configuration with unique dataset names for testing.
+        suffix = uuid.uuid4().hex[:8]
+        self.datasets = Datasets(
+            internal=f"test_dataset_builder_internal_{suffix}",
+            public=f"test_dataset_builder_public_{suffix}",
+            staging=f"test_dataset_builder_staging_{suffix}",
+        )
+        self.config = DatasetBuilderTestMixin._make_test_config(
+            project_id=self.project_id,
+            datasets=self.datasets,
+        )
+
+    def tearDown(self) -> None:
+        for dataset_type in DatasetType:
+            dataset_name = self.datasets.name_for(dataset_type)
+            dataset_fqn = f"{self.project_id}.{dataset_name}"
+            try:
+                self.client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
+            except Exception as e:
+                print(f"Failed to delete {dataset_fqn}: {type(e).__name__}: {e}", file=sys.stderr)
+
+    def test_build_datasets_creates_expected_bigquery_objects(self) -> None:
+        """Test that build_datasets creates expected tables and views.
+
+        Integration test verifying that tables are created with correct
+        fields and clustering, and views have correct columns and FROM
+        clauses.
+        """
+        manager = self._make_integration_manager()
+        manager.build_datasets()
+
+        # The datasets themselves should have been created by build_datasets.
+        for dataset_type in DatasetType:
+            dataset_name = self.datasets.name_for(dataset_type)
+            self.client.get_dataset(f"{self.project_id}.{dataset_name}")
+
+        internal_tables = list(self.client.list_tables(f"{self.project_id}.{self.datasets.internal}"))
+        public_tables = list(self.client.list_tables(f"{self.project_id}.{self.datasets.public}"))
+        staging_tables = list(self.client.list_tables(f"{self.project_id}.{self.datasets.staging}"))
+
+        self.assertEqual(len(internal_tables), 3)
+        self.assertEqual(len(public_tables), 3)
+        self.assertEqual(len(staging_tables), 3)
+
+        # Public dataset should have a properly structured DiaObject table.
+        public_dia_object = self.client.get_table(
+            f"{self.project_id}.{self.datasets.public}.{ApdbTables.DiaObject.value}"
+        )
+        self.assertEqual(public_dia_object.table_type, "TABLE")
+        public_dia_object_field_names = [field.name for field in public_dia_object.schema]
+        self.assertNotIn("validityEndMjdTai", public_dia_object_field_names)
+        self.assertIn("geo_point", public_dia_object_field_names)
+
+        # Public dataset should have views with fully qualified columns and
+        # correct FROM clauses.
+        for table in (ApdbTables.DiaSource, ApdbTables.DiaForcedSource):
+            public_view = self.client.get_table(f"{self.project_id}.{self.datasets.public}.{table.value}")
+            self.assertEqual(public_view.table_type, "VIEW")
+            assert public_view.view_query is not None
+            self.assertIn(
+                f"FROM `{self.project_id}.{self.datasets.internal}.{table.value}`",
+                public_view.view_query,
+            )
+
+        # Staging dataset should have all APDB tables with apdb_replica_chunk
+        # added.
+        for table in (ApdbTables.DiaObject, ApdbTables.DiaSource, ApdbTables.DiaForcedSource):
+            staging_table = self.client.get_table(f"{self.project_id}.{self.datasets.staging}.{table.value}")
+            self.assertEqual(staging_table.table_type, "TABLE")
+            chunk_field = next(field for field in staging_table.schema if field.name == "apdb_replica_chunk")
+            self.assertEqual(chunk_field.field_type, "INTEGER")
+            self.assertEqual(chunk_field.mode, "REQUIRED")
+
+        # Internal dataset should have all APDB tables with geo_point and
+        # geo_point clustering.
+        for table in (ApdbTables.DiaObject, ApdbTables.DiaSource, ApdbTables.DiaForcedSource):
+            internal_table = self.client.get_table(
+                f"{self.project_id}.{self.datasets.internal}.{table.value}"
+            )
+            self.assertEqual(internal_table.table_type, "TABLE")
+            geo_point = next(field for field in internal_table.schema if field.name == "geo_point")
+            self.assertEqual(geo_point.field_type, "GEOGRAPHY")
+            self.assertEqual(geo_point.mode, "REQUIRED")
+            self.assertEqual(internal_table.clustering_fields, ["geo_point"])
+
+    def test_build_datasets_exists_ok_allows_repeated_creation(self) -> None:
+        """Test that build_datasets allows repeated calls with exists_ok.
+
+        Integration test verifying that repeated calls to build_datasets
+        succeed when exists_ok=True and datasets already exist.
+        """
+        manager = self._make_integration_manager(exists_ok=True)
+        manager.build_datasets()
+        manager.build_datasets()
+
+    def test_build_datasets_without_exists_ok_fails_on_repeated_creation(self) -> None:
+        """Test that build_datasets fails without exists_ok on repeat.
+
+        Integration test verifying that calling build_datasets twice without
+        exists_ok=True raises DatasetBuilderError on the second call.
+        """
+        manager = self._make_integration_manager()
+
+        manager.build_datasets()
+
+        with self.assertRaisesRegex(DatasetBuilderError, r"already exists"):
+            manager.build_datasets()
+
+    @unittest.skipUnless(
+        _SEARCH_INDEXES_ENABLED,
+        "Set DAX_PPDB_TESTS_SEARCH_INDEXES_ENABLED=1 to run search index integration tests",
+    )
+    def test_build_datasets_creates_search_indexes(self) -> None:
+        """Test that build_datasets creates search indexes."""
+        manager = self._make_integration_manager()
+        manager.build_datasets()
+
+        internal_indexes = self._list_search_indexes(self.datasets.internal)
+        public_indexes = self._list_search_indexes(self.datasets.public)
+
+        self.assertGreaterEqual(len(internal_indexes), 3)
+        self.assertGreaterEqual(len(public_indexes), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_felis_converter.py
+++ b/tests/test_felis_converter.py
@@ -1,0 +1,119 @@
+# This file is part of dax_ppdb.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import unittest
+
+from felis import datamodel
+
+from lsst.dax.ppdb.bigquery.schema.felis_converter import FelisConverter, FelisConverterError
+
+
+class FelisConverterTestCase(unittest.TestCase):
+    """Unit tests for FelisConverter."""
+
+    def setUp(self) -> None:
+        """Build a minimal converter used by missing-table tests."""
+        table = datamodel.Table(
+            name="KnownTable",
+            id="#KnownTable",
+            columns=[
+                datamodel.Column(
+                    name="id",
+                    id="#KnownTable.id",
+                    datatype=datamodel.DataType.int,
+                    nullable=False,
+                )
+            ],
+        )
+        schema = datamodel.Schema(
+            name="InlineSchema",
+            id="#InlineSchema",
+            tables=[table],
+        )
+        self.converter = FelisConverter(schema)
+
+    def test_convert_tables_maps_all_supported_types_and_modes(self) -> None:
+        """Convert a synthetic table covering all supported Felis types."""
+        expected_types = FelisConverter._TYPE_MAP.copy()
+
+        base_column = datamodel.Column(
+            name="base",
+            id="#TypeCoverage.base",
+            datatype=datamodel.DataType.int,
+            nullable=True,
+        )
+
+        columns: list[datamodel.Column] = []
+        for i, data_type in enumerate(expected_types):
+            column_name = f"c_{data_type.name}"
+            nullable = i % 2 == 0
+            columns.append(
+                base_column.model_copy(
+                    update={
+                        "name": column_name,
+                        "id": f"#TypeCoverage.{column_name}",
+                        "datatype": data_type,
+                        "nullable": nullable,
+                    }
+                )
+            )
+
+        table = datamodel.Table(
+            name="TypeCoverage",
+            id="#TypeCoverage",
+            columns=columns,
+        )
+        schema = datamodel.Schema(
+            name="InlineSchema",
+            id="#InlineSchema",
+            tables=[table],
+        )
+
+        converter = FelisConverter(schema)
+        converted = converter.convert_tables(["TypeCoverage"], "test-project.test_dataset")
+
+        self.assertEqual(len(converted), 1)
+        bq_table = converted[0]
+        self.assertEqual(bq_table.project, "test-project")
+        self.assertEqual(bq_table.dataset_id, "test_dataset")
+        self.assertEqual(bq_table.table_id, "TypeCoverage")
+
+        self.assertEqual(len(bq_table.schema), len(columns))
+        for source_column, field in zip(columns, bq_table.schema, strict=True):
+            self.assertEqual(field.name, source_column.name)
+            self.assertEqual(field.field_type, expected_types[source_column.datatype])
+            self.assertEqual(field.mode, "NULLABLE" if source_column.nullable else "REQUIRED")
+
+    def test_find_table_raises_for_missing_name(self) -> None:
+        """Missing table names should raise FelisConverterError."""
+        with self.assertRaisesRegex(FelisConverterError, r"Table 'MissingTable' not found"):
+            self.converter.find_table("MissingTable")
+
+    def test_convert_tables_raises_for_missing_name(self) -> None:
+        """convert_tables should surface missing table lookup failures."""
+        with self.assertRaisesRegex(FelisConverterError, r"Table 'MissingTable' not found"):
+            self.converter.convert_tables(["MissingTable"], "test-project.test_dataset")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a new module and command-line tool for creating BigQuery datasets for the PPDB from the `ppdb.yaml` Felis schema. Tables can be created from the Felis model and then modified as needed with additional columns, etc. There are also extension points for defining views and search indexes.

There is a new command in the CLI for creating the datasets from a config file:

    ppdb-cli create-datasets ppdb_config.yaml

This new feature was not fully integrated into the other packages or cloud functions. This will be resolved on [DM-54681](https://rubinobs.atlassian.net/browse/DM-54681) as a separate issue.

The datasets created by the tool are:

**Staging**

This dataset contains the tables with staged data inserted by the Dataflow jobs. The standard DIA tables are created with an added `apdb_replica_chunk` column.

**Internal**

This dataset has the target tables for the promotion process. The standard DIA tables are created with an added `geo_point` column. The `DiaObject` table in this dataset contains all record versions, and, in the future, could be mapped to `DiaObject_history` via a view.

**Public**

This dataset has the public tables and views which will be visible to the TAP service via TAP_SCHEMA. The `DiaSource` and `DiaForcedSource` tables are managed as "explicit" BigQuery views listing all of the columns from their respective internal tables. The `DiaObject` table in this dataset will contains only the latest record versions with the `validityEndMjdTai` column dropped. (The `DiaObject` table will be managed as a table rather than a view, because using a materialized view on the internal table would be cumbersome due to table swap operations during promotion. This approach is not implemented yet and will be handled separately on [DM-54475](https://rubinobs.atlassian.net/browse/DM-54475).)

**Additional Features**

There is an optional feature for managing the view permissions on the internal dataset from the public one.

**Notes**

Test coverage of the new modules should actually be 100% or very close, but it isn't showing as such due to tests requiring Google Cloud being skipped in CI. (I plan to resolve this by adding the credentials to the repo but not on this PR.)

[DM-54681]: https://rubinobs.atlassian.net/browse/DM-54681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DM-54475]: https://rubinobs.atlassian.net/browse/DM-54475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ