### PR TITLE
DM-55016: Improvements to ppdb_bigquery module

### DIFF
--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -27,6 +27,7 @@ import logging
 import posixpath
 import sys
 import time
+from pathlib import Path
 
 from lsst.dax.apdb import monitor
 from lsst.dax.apdb.timer import Timer
@@ -37,7 +38,6 @@ from .manifest import Manifest
 from .ppdb_bigquery import PpdbBigQuery
 from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
-from .updates.update_records import UpdateRecords
 
 _LOG = logging.getLogger(__name__)
 
@@ -199,7 +199,6 @@ class ChunkUploader:
         manifest_path = chunk_dir / Manifest.FILE_NAME
 
         # Read the manifest file to get metadata about the chunk.
-        manifest: Manifest | None = None
         try:
             if not manifest_path.exists():
                 raise ChunkUploadError(chunk_id, f"Manifest file does not exist: {manifest_path}")
@@ -208,45 +207,30 @@ class ChunkUploader:
             raise ChunkUploadError(chunk_id, f"Failed to read manifest file for: {replica_chunk.id}") from e
 
         # Construct the GCS prefix for this chunk's files.
-        gcs_prefix = self.config.chunk_object_prefix(chunk_id)
+        gcs_prefix = posixpath.join(self.config.object_prefix, str(chunk_id))
 
-        # Make a list of local parquet files to upload.
-        upload_file_list = list(chunk_dir.glob("*.parquet"))
+        # Make a list of parquet files to upload based on the manifest.
+        upload_file_list = [Path(chunk_dir, file_name) for file_name in manifest.files.keys()]
 
-        # Check if the chunk is expected to be empty.
-        is_empty = manifest.is_empty_chunk()
+        # Check that all expected parquet files from the manifest are present.
+        for expected_file in upload_file_list:
+            if not expected_file.exists():
+                raise ChunkUploadError(
+                    chunk_id,
+                    f"Missing expected parquet file: {expected_file}",
+                )
 
         # Raise an error if no files are present for non-empty chunks since
         # this likely indicates a problem during the export process.
-        if not upload_file_list and not is_empty:
+        if not upload_file_list and not manifest.is_empty_chunk:
             raise ChunkUploadError(chunk_id, f"No files found to upload in {chunk_dir} for non-empty chunk")
 
-        # Check that all expected parquet files from the manifest containing
-        # table data are present.
-        for table_name, table_stats in manifest.table_data.items():
-            if table_stats.row_count > 0:
-                expected_file = chunk_dir / f"{table_name}.parquet"
-                if not expected_file.exists():
-                    raise ChunkUploadError(
-                        chunk_id,
-                        f"Expected parquet file for table '{table_name}' does not exist: {expected_file}",
-                    )
-
-        # Ensure that the parquet file containing updates exists if the
-        # manifest indicates that there are update records in this chunk.
-        if manifest.update_count > 0:
-            update_records_file = chunk_dir / UpdateRecords.PARQUET_FILE_NAME
-            if not update_records_file.exists():
-                raise ChunkUploadError(
-                    chunk_id,
-                    f"Manifest indicates that replica chunk {chunk_id} has update records but file does not "
-                    f"exist: {update_records_file}",
-                )
-
         try:
-            # 1) Upload the files to GCS for non-empty chunks.
+            # 1) Upload the parquet files to GCS for non-empty chunks.
             if upload_file_list:
-                gcs_names = {path: posixpath.join(gcs_prefix, path.name) for path in upload_file_list}
+                gcs_names = {
+                    file_path: posixpath.join(gcs_prefix, file_path.name) for file_path in upload_file_list
+                }
                 try:
                     _LOG.info(
                         "Uploading %d files to: gcs://%s",
@@ -272,12 +256,12 @@ class ChunkUploader:
                 raise ChunkUploadError(chunk_id, "Manifest upload failed") from e
 
             # Next two steps are inapplicable to empty chunks.
-            if not is_empty:
+            if not manifest.is_empty_chunk:
                 # 3) Update the status and GCS URI in the database, marking
                 # chunks with no table data as "staged" since they don't need
                 # to go through the staging process in Dataflow.
                 gcs_uri = posixpath.join(self.config.bucket_name, gcs_prefix)
-                status = ChunkStatus.UPLOADED if manifest.has_table_data() else ChunkStatus.STAGED
+                status = ChunkStatus.UPLOADED if manifest.has_table_data else ChunkStatus.STAGED
                 updated_replica_chunk = replica_chunk.with_new_status(status).with_new_gcs_uri(
                     f"gs://{gcs_uri}"
                 )
@@ -294,7 +278,7 @@ class ChunkUploader:
 
                 # 4) Publish Pub/Sub event to trigger the Dataflow staging
                 # job for chunks with table data (skipped for updates-only).
-                if manifest.has_table_data():
+                if manifest.has_table_data:
                     try:
                         self._post_to_stage_chunk_topic(gcs_uri, chunk_id)
                     except Exception as e:

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -210,7 +210,12 @@ class ChunkUploader:
         gcs_prefix = posixpath.join(self.config.object_prefix, str(chunk_id))
 
         # Make a list of parquet files to upload based on the manifest.
-        upload_file_list = [Path(chunk_dir, file_name) for file_name in manifest.files.keys()]
+        upload_file_list: list[Path] = []
+        for file_name in manifest.files.keys():
+            safe_name = Path(file_name).name
+            if safe_name != file_name:
+                raise ChunkUploadError(chunk_id, f"Invalid parquet file name in manifest: {file_name}")
+            upload_file_list.append(chunk_dir / safe_name)
 
         # Check that all expected parquet files from the manifest are present.
         for expected_file in upload_file_list:
@@ -247,6 +252,7 @@ class ChunkUploader:
                     raise ChunkUploadError(chunk_id, f"{len(eg.exceptions)} upload(s) failed") from eg
 
             # 2) Upload manifest, even for empty chunks.
+            gcs_uri = posixpath.join(self.config.bucket_name, gcs_prefix)
             try:
                 self._storage.upload_from_string(
                     posixpath.join(gcs_prefix, manifest_path.name),
@@ -260,7 +266,6 @@ class ChunkUploader:
                 # 3) Update the status and GCS URI in the database, marking
                 # chunks with no table data as "staged" since they don't need
                 # to go through the staging process in Dataflow.
-                gcs_uri = posixpath.join(self.config.bucket_name, gcs_prefix)
                 status = ChunkStatus.UPLOADED if manifest.has_table_data else ChunkStatus.STAGED
                 updated_replica_chunk = replica_chunk.with_new_status(status).with_new_gcs_uri(
                     f"gs://{gcs_uri}"

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -248,7 +248,11 @@ class ChunkUploader:
             if upload_file_list:
                 gcs_names = {path: posixpath.join(gcs_prefix, path.name) for path in upload_file_list}
                 try:
-                    _LOG.info("Uploading %d files to GCS under prefix: %s", len(gcs_names), gcs_prefix)
+                    _LOG.info(
+                        "Uploading %d files to: gcs://%s",
+                        len(gcs_names),
+                        posixpath.join(self.config.bucket_name, gcs_prefix),
+                    )
                     with Timer(
                         "upload_files_time", _MON, tags={"prefix": str(gcs_prefix), "chunk_id": str(chunk_id)}
                     ) as timer:

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -27,7 +27,6 @@ import logging
 import posixpath
 import sys
 import time
-from pathlib import Path
 
 from lsst.dax.apdb import monitor
 from lsst.dax.apdb.timer import Timer
@@ -194,25 +193,24 @@ class ChunkUploader:
         """
         chunk_id = replica_chunk.id
 
-        if replica_chunk.directory is None:
-            raise ChunkUploadError(chunk_id, "No directory specified on replica chunk")
-        chunk_dir = replica_chunk.directory
+        # Determine the local chunk directory from the chunk ID rather than
+        # reading it from the database.
+        chunk_dir = self.config.replication_path / str(chunk_id)
+        manifest_path = chunk_dir / Manifest.FILE_NAME
 
         # Read the manifest file to get metadata about the chunk.
         manifest: Manifest | None = None
         try:
-            if not replica_chunk.manifest_path.exists():
-                raise ChunkUploadError(
-                    chunk_id, f"Manifest file does not exist: {replica_chunk.manifest_path}"
-                )
-            manifest = Manifest.from_json_file(replica_chunk.manifest_path)
+            if not manifest_path.exists():
+                raise ChunkUploadError(chunk_id, f"Manifest file does not exist: {manifest_path}")
+            manifest = Manifest.from_json_file(manifest_path)
         except Exception as e:
             raise ChunkUploadError(chunk_id, f"Failed to read manifest file for: {replica_chunk.id}") from e
 
         # Construct the GCS prefix for this chunk's files.
         gcs_prefix = posixpath.join(
             self.config.object_prefix,
-            f"{manifest.exported_at.strftime('%Y/%m/%d')}/{chunk_id}",
+            str(chunk_id),
         )
 
         # Make a list of local parquet files to upload.
@@ -266,7 +264,7 @@ class ChunkUploader:
             # 2) Upload manifest, even for empty chunks.
             try:
                 self._storage.upload_from_string(
-                    posixpath.join(gcs_prefix, Path(replica_chunk.manifest_path).name),
+                    posixpath.join(gcs_prefix, manifest_path.name),
                     manifest.model_dump_json(),
                 )
             except UploadError as e:

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -208,10 +208,7 @@ class ChunkUploader:
             raise ChunkUploadError(chunk_id, f"Failed to read manifest file for: {replica_chunk.id}") from e
 
         # Construct the GCS prefix for this chunk's files.
-        gcs_prefix = posixpath.join(
-            self.config.object_prefix,
-            str(chunk_id),
-        )
+        gcs_prefix = self.config.chunk_object_prefix(chunk_id)
 
         # Make a list of local parquet files to upload.
         upload_file_list = list(chunk_dir.glob("*.parquet"))

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -211,7 +211,7 @@ class ChunkUploader:
 
         # Make a list of parquet files to upload based on the manifest.
         upload_file_list: list[Path] = []
-        for file_name in manifest.files.keys():
+        for file_name in manifest.files:
             safe_name = Path(file_name).name
             if safe_name != file_name:
                 raise ChunkUploadError(chunk_id, f"Invalid parquet file name in manifest: {file_name}")

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -183,7 +183,7 @@ class ChunkUploader:
         Parameters
         ----------
         replica_chunk
-            The replica chunk to process, which includes its ID and directory.
+            The replica chunk to process.
 
         Raises
         ------
@@ -193,9 +193,9 @@ class ChunkUploader:
         """
         chunk_id = replica_chunk.id
 
-        # Determine the local chunk directory from the chunk ID rather than
-        # reading it from the database.
-        chunk_dir = self.config.replication_path / str(chunk_id)
+        # Determine the local directory where the chunk's parquet files and
+        # manifest are stored.
+        chunk_dir = self.config.chunk_dir(chunk_id)
         manifest_path = chunk_dir / Manifest.FILE_NAME
 
         # Read the manifest file to get metadata about the chunk.

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -21,8 +21,9 @@
 
 from __future__ import annotations
 
-__all__ = ["Manifest", "TableStats"]
+__all__ = ["Manifest", "ParquetFileStats"]
 
+import hashlib
 import json
 import os
 from datetime import UTC, datetime
@@ -38,11 +39,57 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
-class TableStats(BaseModel):
-    """Per-table file statistics."""
+class ParquetFileStats(BaseModel):
+    """Per-parquet-file statistics."""
 
     row_count: int = Field(ge=0, description="Non-negative count of rows written for this table.")
     """Number of rows written for this table (must be non-negative)."""
+
+    checksum: str | None = None
+    """SHA-256 checksum for this parquet file, if one was written."""
+
+    size_bytes: int | None = None
+    """Size of this parquet file in bytes, if one was written."""
+
+    @staticmethod
+    def compute_checksum(file_path: Path) -> str | None:
+        """Compute the SHA-256 checksum of a file.
+
+        Parameters
+        ----------
+        file_path
+            Path to the file.
+
+        Returns
+        -------
+        `str` or `None`
+            SHA-256 hex digest, or `None` if the file does not exist.
+        """
+        if not file_path.exists():
+            return None
+        digest = hashlib.sha256()
+        with open(file_path, "rb") as fd:
+            for chunk in iter(lambda: fd.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    @staticmethod
+    def compute_size(file_path: Path) -> int | None:
+        """Return the size of a file in bytes.
+
+        Parameters
+        ----------
+        file_path
+            Path to the file.
+
+        Returns
+        -------
+        `int` or `None`
+            File size in bytes, or `None` if the file does not exist.
+        """
+        if not file_path.exists():
+            return None
+        return file_path.stat().st_size
 
 
 class Manifest(BaseModel):
@@ -75,9 +122,12 @@ class Manifest(BaseModel):
     """Source system's last-update timestamp for the replica; TAI value, kept
     as string to avoid any precision issues (`str`)."""
 
-    table_data: dict[str, TableStats]
+    table_data: dict[str, ParquetFileStats]
     """Mapping of table name to per-table statistics
-    (`dict` [`str`, `TableStats`])."""
+    (`dict` [`str`, `ParquetFileStats`])."""
+
+    updates_data: ParquetFileStats | None = None
+    """Statistics for ``update_records.parquet`` when update records exist."""
 
     compression_format: str
     """Name of the compression format used for artifacts (e.g., "gzip",

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -59,6 +59,28 @@ class ParquetFileEntry(BaseModel):
     size_bytes: int = Field(ge=1, description="Size of this parquet file in bytes.")
     """Size of this parquet file in bytes."""
 
+    @classmethod
+    def from_path(cls, path: Path, row_count: int) -> ParquetFileEntry:
+        """Create a `ParquetFileEntry` from a parquet file path and row count.
+
+        Parameters
+        ----------
+        path
+            Path to the parquet file.
+        row_count
+            Number of rows written for this table.
+
+        Returns
+        -------
+        `ParquetFileEntry`
+            The created `ParquetFileEntry` object.
+        """
+        return cls(
+            row_count=row_count,
+            checksum=cls.compute_checksum(path),
+            size_bytes=cls.compute_size(path),
+        )
+
     @staticmethod
     def compute_checksum(file_path: Path) -> str:
         """Compute the SHA-256 checksum of a file.
@@ -76,7 +98,7 @@ class ParquetFileEntry(BaseModel):
         Raises
         ------
         FileNotFoundError
-            If the file does not exist.
+            Raised if the file does not exist.
         """
         if not file_path.exists():
             raise FileNotFoundError(f"File not found: {file_path}")

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -21,7 +21,7 @@
 
 from __future__ import annotations
 
-__all__ = ["Manifest", "ParquetFileStats"]
+__all__ = ["Manifest", "ParquetFileEntry"]
 
 import hashlib
 import json
@@ -33,26 +33,33 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from .updates import UpdateRecords
+
 
 def _utc_now() -> datetime:
     """Return the current UTC time as a timezone-aware datetime."""
     return datetime.now(UTC)
 
 
-class ParquetFileStats(BaseModel):
-    """Per-parquet-file statistics."""
+class ParquetFileEntry(BaseModel):
+    """Information about a single parquet file for the replica chunk.
 
-    row_count: int = Field(ge=0, description="Non-negative count of rows written for this table.")
+    Non-existent files, e.g. where data for the table was not present in the
+    chunk, should not have entries. Their absence from the manifest indicates
+    that they were not written.
+    """
+
+    row_count: int = Field(ge=1, description="Count of rows written for this table.")
     """Number of rows written for this table (must be non-negative)."""
 
     checksum: str | None = None
-    """SHA-256 checksum for this parquet file, if one was written."""
+    """SHA-256 checksum for this parquet file."""
 
     size_bytes: int | None = None
-    """Size of this parquet file in bytes, if one was written."""
+    """Size of this parquet file in bytes."""
 
     @staticmethod
-    def compute_checksum(file_path: Path) -> str | None:
+    def compute_checksum(file_path: Path) -> str:
         """Compute the SHA-256 checksum of a file.
 
         Parameters
@@ -62,19 +69,25 @@ class ParquetFileStats(BaseModel):
 
         Returns
         -------
-        `str` or `None`
-            SHA-256 hex digest, or `None` if the file does not exist.
+        `str`
+            SHA-256 hex digest of the file contents.
+
+        Raises
+        ------
+        FileNotFoundError
+            If the file does not exist.
         """
         if not file_path.exists():
-            return None
+            raise FileNotFoundError(f"File not found: {file_path}")
         digest = hashlib.sha256()
         with open(file_path, "rb") as fd:
-            for chunk in iter(lambda: fd.read(1024 * 1024), b""):
+            chunk_size = 1024 * 1024
+            while chunk := fd.read(chunk_size):
                 digest.update(chunk)
         return digest.hexdigest()
 
     @staticmethod
-    def compute_size(file_path: Path) -> int | None:
+    def compute_size(file_path: Path) -> int:
         """Return the size of a file in bytes.
 
         Parameters
@@ -84,11 +97,11 @@ class ParquetFileStats(BaseModel):
 
         Returns
         -------
-        `int` or `None`
-            File size in bytes, or `None` if the file does not exist.
+        `int`
+            File size in bytes.
         """
         if not file_path.exists():
-            return None
+            raise FileNotFoundError(f"File not found: {file_path}")
         return file_path.stat().st_size
 
 
@@ -103,38 +116,53 @@ class Manifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     """Pydantic model configuration."""
 
+    schema_version: str
+    """Version string of the schema used to produce this export (`str`)."""
+
     replica_chunk_id: str
-    """Sequential identifier of the replica chunk being exporter (`str`)."""
+    """Sequential identifier of the replica chunk (`str`)."""
 
     unique_id: UUID
     """Globally unique opaque identifier for the export operation or replica
     (`uuid.UUID`).
     """
 
-    schema_version: str
-    """Version string of the schema used to produce this export (`str`)."""
-
     exported_at: datetime = Field(default_factory=_utc_now)
     """Timestamp when the export was produced (UTC). Serialized as ISO 8601
-    (`datetime`)."""
+    (`datetime`).
+    """
 
     last_update_time: str
     """Source system's last-update timestamp for the replica; TAI value, kept
     as string to avoid any precision issues (`str`)."""
 
-    table_data: dict[str, ParquetFileStats]
-    """Mapping of table name to per-table statistics
-    (`dict` [`str`, `ParquetFileStats`])."""
-
-    updates_data: ParquetFileStats | None = None
-    """Statistics for ``update_records.parquet`` when update records exist."""
-
     compression_format: str
     """Name of the compression format used for artifacts (e.g., "gzip",
     "zstd", "snappy", etc.)."""
 
-    update_count: int = Field(default=0, ge=0)
-    """Number of update records included in the exported data (`int`)."""
+    files: dict[str, ParquetFileEntry] = Field(default_factory=dict)
+    """Mapping of parquet file names to their entries."""
+
+    @property
+    def is_empty_chunk(self) -> bool:
+        """`True` if the manifest represents an empty replica chunk with no
+        table data or update records, `False` otherwise (`bool`).
+        """
+        return len(self.files) == 0
+
+    @property
+    def has_table_data(self) -> bool:
+        """`True` if the chunk contains any parquet files with table data,
+        `False` otherwise (`bool`).
+        """
+        return any(name != UpdateRecords.PARQUET_FILE_NAME for name in self.files)
+
+    @property
+    def has_update_records(self) -> bool:
+        """`True` if the chunk contains the update records parquet file,
+        `False` otherwise (`bool`).
+        """
+        return UpdateRecords.PARQUET_FILE_NAME in self.files
 
     def write_json_file(self, dir_path: Path) -> None:
         """Save the manifest to a JSON file in the specified directory.
@@ -177,27 +205,3 @@ class Manifest(BaseModel):
         """
         data = json.loads(content)
         return cls.model_validate(data)
-
-    def is_empty_chunk(self) -> bool:
-        """Check if the manifest represents an empty replica chunk in which
-        all tables have zero rows and no update records are included.
-
-        Returns
-        -------
-        `bool`
-            `True` if all tables have zero rows and no update records are
-            included, indicating an empty chunk, `False` otherwise.
-        """
-        return all(table.row_count == 0 for table in self.table_data.values()) and self.update_count == 0
-
-    def has_table_data(self) -> bool:
-        """Check if the manifest contains any table data with non-zero row
-        counts.
-
-        Returns
-        -------
-        bool
-            `True` if at least one table has a non-zero row count, `False`
-            otherwise.
-        """
-        return any(table.row_count > 0 for table in self.table_data.values())

--- a/python/lsst/dax/ppdb/bigquery/manifest.py
+++ b/python/lsst/dax/ppdb/bigquery/manifest.py
@@ -46,16 +46,17 @@ class ParquetFileEntry(BaseModel):
 
     Non-existent files, e.g. where data for the table was not present in the
     chunk, should not have entries. Their absence from the manifest indicates
-    that they were not written.
+    that they were not written. Empty files (no rows) should also not have
+    entries as they would result in no-ops when loading the data into BigQuery.
     """
 
     row_count: int = Field(ge=1, description="Count of rows written for this table.")
-    """Number of rows written for this table (must be non-negative)."""
+    """Number of rows written for this table (must be positive)."""
 
-    checksum: str | None = None
+    checksum: str
     """SHA-256 checksum for this parquet file."""
 
-    size_bytes: int | None = None
+    size_bytes: int = Field(ge=1, description="Size of this parquet file in bytes.")
     """Size of this parquet file in bytes."""
 
     @staticmethod

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -348,7 +348,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
     @classmethod
     def create_replica_chunk_table(cls, table_name: str | None = None) -> schema_model.Table:
         """Create the ``PpdbReplicaChunk`` table with additional fields for
-        status and directory.
+        replication tracking.
 
         Parameters
         ----------
@@ -359,7 +359,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         Notes
         -----
         This overrides the base method to add additional columns for
-        ``status`` and ``directory`` to the replica chunk table schema.
+        ``status``, ``gcs_uri``, and ``update_count`` to the replica chunk
+        table schema.
         """
         replica_chunk_table = super().create_replica_chunk_table(table_name)
         replica_chunk_table.columns.extend(
@@ -370,13 +371,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                     name="status",
                     id=f"#{table_name}.status",
                     datatype=felis.datamodel.DataType.string,
-                ),
-                # Local directory where the chunk data is stored for export.
-                schema_model.Column(
-                    name="directory",
-                    id=f"#{table_name}.directory",
-                    datatype=felis.datamodel.DataType.string,
-                    nullable=True,  # We might want to allow NULL if an error occurs when exporting.
                 ),
                 # URI of the chunk data in GCS after it has been uploaded.
                 # This is not a full object path but a prefix ("directory")
@@ -478,9 +472,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             status = ChunkStatus.EXPORTED
 
         # Store the replica chunk info in the database, including status,
-        # directory, and update count.
+        # GCS URI, and update count.
         replica_chunk_ext = PpdbReplicaChunkExtended.from_replica_chunk(
-            replica_chunk, status, chunk_dir, len(update_records)
+            replica_chunk, status, len(update_records)
         )
         try:
             self.insert_chunks([replica_chunk_ext])
@@ -540,7 +534,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                         unique_id=row["unique_id"],
                         replica_time=astropy.time.Time(row["replica_time"], format="datetime", scale="tai"),
                         status=ChunkStatus(row["status"]),
-                        directory=Path(row["directory"]),
                         gcs_uri=row["gcs_uri"],
                         update_count=row["update_count"],
                     )
@@ -718,10 +711,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         `pathlib.Path`
             Path to the created directory for the replica chunk.
         """
-        chunk_dir = Path(
-            self.config.replication_path,
-            str(chunk.id),
-        )
+        chunk_dir = self.config.chunk_dir(chunk.id)
         if chunk_dir.exists():
             if not self.config.delete_existing_dirs:
                 raise FileExistsError(f"Directory already exists for {chunk.id}: {chunk_dir}")

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -691,12 +691,12 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         # Add file data for each table if it has rows.
         file_entries = {
             f"{table_name}.parquet": ParquetFileEntry(
-                row_count=len(data.rows()),
+                row_count=row_count,
                 checksum=ParquetFileEntry.compute_checksum(chunk_dir / f"{table_name}.parquet"),
                 size_bytes=ParquetFileEntry.compute_size(chunk_dir / f"{table_name}.parquet"),
             )
             for table_name, data in table_dict.items()
-            if len(data.rows()) > 0
+            if (row_count := len(data.rows())) > 0
         }
 
         # Add file data for the update records if they exist.

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -706,8 +706,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         )
 
     def _create_chunk_dir(self, chunk: ReplicaChunk) -> Path:
-        """Create the directory for the replica chunk based on its last update
-        time and ID.
+        """Create the directory for the replica chunk based on its ID.
 
         Parameters
         ----------
@@ -719,11 +718,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         `pathlib.Path`
             Path to the created directory for the replica chunk.
         """
-        last_update_time = chunk.last_update_time.to_datetime()
-        assert isinstance(last_update_time, datetime.datetime)
         chunk_dir = Path(
             self.config.replication_path,
-            chunk.last_update_time.strftime("%Y/%m/%d"),
             str(chunk.id),
         )
         if chunk_dir.exists():

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -690,10 +690,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         """
         # Add file data for each table if it has rows.
         file_entries = {
-            f"{table_name}.parquet": ParquetFileEntry(
+            f"{table_name}.parquet": ParquetFileEntry.from_path(
+                path=chunk_dir / f"{table_name}.parquet",
                 row_count=row_count,
-                checksum=ParquetFileEntry.compute_checksum(chunk_dir / f"{table_name}.parquet"),
-                size_bytes=ParquetFileEntry.compute_size(chunk_dir / f"{table_name}.parquet"),
             )
             for table_name, data in table_dict.items()
             if (row_count := len(data.rows())) > 0
@@ -701,10 +700,9 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         # Add file data for the update records if they exist.
         if update_records:
-            file_entries[UpdateRecords.PARQUET_FILE_NAME] = ParquetFileEntry(
+            file_entries[UpdateRecords.PARQUET_FILE_NAME] = ParquetFileEntry.from_path(
+                path=chunk_dir / UpdateRecords.PARQUET_FILE_NAME,
                 row_count=len(update_records),
-                checksum=ParquetFileEntry.compute_checksum(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
-                size_bytes=ParquetFileEntry.compute_size(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
             )
 
         return Manifest(

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -50,7 +50,7 @@ from lsst.dax.apdb.timer import Timer
 from .._arrow import write_parquet
 from ..ppdb import Ppdb, PpdbReplicaChunk
 from ..sql import PasswordProvider, PpdbSqlBase, PpdbSqlBaseConfig
-from .manifest import Manifest, TableStats
+from .manifest import Manifest, ParquetFileStats
 from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .updates.update_records import UpdateRecords
@@ -448,7 +448,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
             # Create manifest for the replica chunk.
             try:
-                manifest = self._generate_manifest(replica_chunk, table_dict, update_records)
+                manifest = self._generate_manifest(replica_chunk, table_dict, update_records, chunk_dir)
                 _LOG.info("Generated manifest for %s: %s", replica_chunk.id, manifest.model_dump_json())
             except Exception:
                 _LOG.exception("Failed to generate manifest for %d", replica_chunk.id)
@@ -667,6 +667,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         replica_chunk: ReplicaChunk,
         table_dict: dict[str, ApdbTableData],
         update_records: Collection[ApdbUpdateRecord],
+        chunk_dir: Path,
     ) -> Manifest:
         """Generate the manifest data for the replica chunk.
 
@@ -679,6 +680,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             chunk.
         update_records
             Collection of update records included in the chunk.
+        chunk_dir
+            Local directory where chunk parquet files were written.
 
         Returns
         -------
@@ -692,8 +695,22 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             exported_at=datetime.datetime.now(datetime.UTC),
             last_update_time=str(replica_chunk.last_update_time),  # TAI value
             table_data={
-                table_name: TableStats(row_count=len(data.rows())) for table_name, data in table_dict.items()
+                table_name: ParquetFileStats(
+                    row_count=len(data.rows()),
+                    checksum=ParquetFileStats.compute_checksum(chunk_dir / f"{table_name}.parquet"),
+                    size_bytes=ParquetFileStats.compute_size(chunk_dir / f"{table_name}.parquet"),
+                )
+                for table_name, data in table_dict.items()
             },
+            updates_data=(
+                ParquetFileStats(
+                    row_count=len(update_records),
+                    checksum=ParquetFileStats.compute_checksum(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
+                    size_bytes=ParquetFileStats.compute_size(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
+                )
+                if update_records
+                else None
+            ),
             compression_format=self.config.parq_compression,
             update_count=len(update_records),
         )

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -50,7 +50,7 @@ from lsst.dax.apdb.timer import Timer
 from .._arrow import write_parquet
 from ..ppdb import Ppdb, PpdbReplicaChunk
 from ..sql import PasswordProvider, PpdbSqlBase, PpdbSqlBaseConfig
-from .manifest import Manifest, ParquetFileStats
+from .manifest import Manifest, ParquetFileEntry
 from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .updates.update_records import UpdateRecords
@@ -411,7 +411,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         _LOG.info("Processing %s", replica_chunk.id)
 
         try:
-            chunk_dir = self._create_chunk_dir(replica_chunk)
+            chunk_dir = self._make_chunk_dir(replica_chunk)
 
             if update_records:
                 self._handle_updates(replica_chunk, update_records, chunk_dir)
@@ -464,7 +464,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             _LOG.exception("Failed to store replica chunk: %s", replica_chunk.id)
             raise
 
-        if manifest.is_empty_chunk():
+        if manifest.is_empty_chunk:
             # Mark as skipped if there is no data to export.
             status = ChunkStatus.SKIPPED
             _LOG.warning("No data to export for %s, marking chunk as skipped", replica_chunk.id)
@@ -472,7 +472,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             status = ChunkStatus.EXPORTED
 
         # Store the replica chunk info in the database, including status,
-        # GCS URI, and update count.
+        # and update count.
         replica_chunk_ext = PpdbReplicaChunkExtended.from_replica_chunk(
             replica_chunk, status, len(update_records)
         )
@@ -688,35 +688,38 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         Manifest
             The manifest created from the input data.
         """
+        # Add file data for each table if it has rows.
+        file_entries = {
+            f"{table_name}.parquet": ParquetFileEntry(
+                row_count=len(data.rows()),
+                checksum=ParquetFileEntry.compute_checksum(chunk_dir / f"{table_name}.parquet"),
+                size_bytes=ParquetFileEntry.compute_size(chunk_dir / f"{table_name}.parquet"),
+            )
+            for table_name, data in table_dict.items()
+            if len(data.rows()) > 0
+        }
+
+        # Add file data for the update records if they exist.
+        if update_records:
+            file_entries[UpdateRecords.PARQUET_FILE_NAME] = ParquetFileEntry(
+                row_count=len(update_records),
+                checksum=ParquetFileEntry.compute_checksum(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
+                size_bytes=ParquetFileEntry.compute_size(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
+            )
+
         return Manifest(
             replica_chunk_id=str(replica_chunk.id),
             unique_id=replica_chunk.unique_id,
             schema_version=str(self.schema_version),
             exported_at=datetime.datetime.now(datetime.UTC),
             last_update_time=str(replica_chunk.last_update_time),  # TAI value
-            table_data={
-                table_name: ParquetFileStats(
-                    row_count=len(data.rows()),
-                    checksum=ParquetFileStats.compute_checksum(chunk_dir / f"{table_name}.parquet"),
-                    size_bytes=ParquetFileStats.compute_size(chunk_dir / f"{table_name}.parquet"),
-                )
-                for table_name, data in table_dict.items()
-            },
-            updates_data=(
-                ParquetFileStats(
-                    row_count=len(update_records),
-                    checksum=ParquetFileStats.compute_checksum(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
-                    size_bytes=ParquetFileStats.compute_size(chunk_dir / UpdateRecords.PARQUET_FILE_NAME),
-                )
-                if update_records
-                else None
-            ),
+            files=file_entries,
             compression_format=self.config.parq_compression,
-            update_count=len(update_records),
         )
 
-    def _create_chunk_dir(self, chunk: ReplicaChunk) -> Path:
-        """Create the directory for the replica chunk based on its ID.
+    def _make_chunk_dir(self, chunk: ReplicaChunk) -> Path:
+        """Make the directory for the replica chunk within the replication
+        staging area.
 
         Parameters
         ----------

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -19,8 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from enum import StrEnum
 import posixpath
+from enum import StrEnum
 from pathlib import Path
 
 from pydantic import BaseModel

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -126,6 +126,22 @@ class PpdbBigQueryConfig(PpdbConfig):
         """Return path for writing replica chunk data (`pathlib.Path`)."""
         return Path(self.replication_dir)
 
+    def chunk_dir(self, chunk_id: int) -> Path:
+        """Return the local directory for a replica chunk's data.
+
+        Parameters
+        ----------
+        chunk_id
+            ID of the replica chunk.
+
+        Returns
+        -------
+        `pathlib.Path`
+            Path to the chunk's local directory, formed by convention from
+            the replication path and the chunk ID.
+        """
+        return self.replication_path / str(chunk_id)
+
     # TODO: This function should be removed by DM-54681.
     @property
     def fq_dataset_id(self) -> str:

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from enum import StrEnum
+import posixpath
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -141,6 +142,22 @@ class PpdbBigQueryConfig(PpdbConfig):
             the replication path and the chunk ID.
         """
         return self.replication_path / str(chunk_id)
+
+    def chunk_object_prefix(self, chunk_id: int) -> str:
+        """Return the cloud object-prefix for a replica chunk's data.
+
+        Parameters
+        ----------
+        chunk_id
+            ID of the replica chunk.
+
+        Returns
+        -------
+        `str`
+            Object-prefix for the chunk in cloud storage, formed by
+            convention from the base object prefix and the chunk ID.
+        """
+        return posixpath.join(self.object_prefix, str(chunk_id))
 
     # TODO: This function should be removed by DM-54681.
     @property

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -19,7 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import posixpath
 from enum import StrEnum
 from pathlib import Path
 
@@ -142,22 +141,6 @@ class PpdbBigQueryConfig(PpdbConfig):
             the replication path and the chunk ID.
         """
         return self.replication_path / str(chunk_id)
-
-    def chunk_object_prefix(self, chunk_id: int) -> str:
-        """Return the cloud object-prefix for a replica chunk's data.
-
-        Parameters
-        ----------
-        chunk_id
-            ID of the replica chunk.
-
-        Returns
-        -------
-        `str`
-            Object-prefix for the chunk in cloud storage, formed by
-            convention from the base object prefix and the chunk ID.
-        """
-        return posixpath.join(self.object_prefix, str(chunk_id))
 
     # TODO: This function should be removed by DM-54681.
     @property

--- a/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_replica_chunk_extended.py
@@ -27,7 +27,6 @@ import dataclasses
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import astropy.time
@@ -38,7 +37,6 @@ if TYPE_CHECKING:
 from lsst.dax.apdb import ReplicaChunk
 
 from ..ppdb import PpdbReplicaChunk
-from .manifest import Manifest
 
 
 class ChunkStatus(StrEnum):
@@ -65,9 +63,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
     status: ChunkStatus
     """Status of the replica chunk."""
 
-    directory: Path
-    """Directory where the exported replica chunk data is stored locally."""
-
     gcs_uri: str | None = None
     """GCS URI where the replica chunk data is stored, or `None` if not
     uploaded yet."""
@@ -75,15 +70,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
     update_count: int = 0
     """Count of APDB update records included in the chunk
     (must be non-negative)."""
-
-    @property
-    def manifest_path(self) -> Path:
-        """Path to the manifest file for this chunk, or `None` if directory is
-        not set.
-        """
-        if self.directory is None:
-            raise ValueError(f"directory for replica chunk {self.id} is not set")
-        return self.directory / Manifest.FILE_NAME
 
     @property
     def replica_time_dt_utc(self) -> datetime:
@@ -100,7 +86,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
         cls,
         replica_chunk: ReplicaChunk,
         status: ChunkStatus,
-        directory: Path,
         update_count: int = 0,
     ) -> PpdbReplicaChunkExtended:
         """Create a `PpdbReplicaChunkExtended` from a
@@ -112,8 +97,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
             The `~lsst.dax.apdb.ReplicaChunk` to convert.
         status
             Status of the replica chunk.
-        directory
-            Directory where the replica chunk data is stored.
 
         Returns
         -------
@@ -126,7 +109,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
             last_update_time=replica_chunk.last_update_time,
             replica_time=astropy.time.Time.now(),
             status=status,
-            directory=directory,
             update_count=update_count,
         )
 
@@ -177,7 +159,6 @@ class PpdbReplicaChunkExtended(PpdbReplicaChunk):
             "unique_id": self.unique_id,
             "replica_time": self.replica_time_dt_utc,
             "status": self.status.value,
-            "directory": str(self.directory),
             "gcs_uri": self.gcs_uri,  # This field can be null.
             "update_count": self.update_count,
         }

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -41,7 +41,6 @@ from lsst.dax.apdb import (
 from lsst.dax.apdb.sql import ApdbSql
 from lsst.dax.ppdb import PpdbConfig
 from lsst.dax.ppdb.bigquery import PpdbBigQuery
-from lsst.dax.ppdb.bigquery.chunk_uploader import ChunkUploader
 from lsst.dax.ppdb.tests._ppdb import TEST_SCHEMA_RESOURCE_PATH
 
 try:
@@ -51,7 +50,6 @@ except ImportError:
 
 __all__ = [
     "TEST_CONFIG",
-    "ChunkUploaderWithoutPubSub",
     "PostgresMixin",
     "SqliteMixin",
     "delete_test_bucket",
@@ -112,20 +110,6 @@ def delete_test_bucket(bucket_or_bucket_name: str | storage.Bucket) -> None:
         bucket.delete()
     except Exception as e:
         _LOG.exception("Failed to delete test GCS bucket: %s", e)
-
-
-class ChunkUploaderWithoutPubSub(ChunkUploader):
-    """A dummy implementation of the ChunkUploader that does not actually
-    post messages to Pub/Sub.
-    """
-
-    def _post_to_stage_chunk_topic(self, gcs_uri: str, chunk_id: int) -> None:
-        message = {
-            "dataset": None,
-            "chunk_id": str(chunk_id),
-            "folder": f"gs://{gcs_uri}",
-        }
-        print(f"Dummy publish to Pub/Sub topic: {message}")
 
 
 class SqliteMixin:

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import posixpath
 import unittest
 import uuid
 from pathlib import Path
@@ -126,8 +127,8 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         for chunk in self.ppdb.query_chunks():
             chunk_dir = self.ppdb.config.chunk_dir(chunk.id)
             manifest = Manifest.from_json_file(chunk_dir / Manifest.FILE_NAME)
-            status = ChunkStatus.UPLOADED if manifest.has_table_data() else ChunkStatus.STAGED
-            gcs_prefix = self.ppdb.config.chunk_object_prefix(chunk.id)
+            status = ChunkStatus.UPLOADED if manifest.has_table_data else ChunkStatus.STAGED
+            gcs_prefix = posixpath.join(self.ppdb.config.object_prefix, str(chunk.id))
             gcs_uri = f"gs://{bucket_name}/{gcs_prefix}"
 
             update_records_path = chunk_dir / UpdateRecords.PARQUET_FILE_NAME

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -124,12 +124,13 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         # are not attempting to test that functionality here and the parquet
         # files do not need to be uploaded for the test.
         for chunk in self.ppdb.query_chunks():
-            manifest = Manifest.from_json_file(chunk.manifest_path)
+            chunk_dir = self.ppdb.config.chunk_dir(chunk.id)
+            manifest = Manifest.from_json_file(chunk_dir / Manifest.FILE_NAME)
             status = ChunkStatus.UPLOADED if manifest.has_table_data() else ChunkStatus.STAGED
             gcs_prefix = f"data/test/{chunk.id}"
             gcs_uri = f"gs://{bucket_name}/{gcs_prefix}"
 
-            update_records_path = chunk.directory / UpdateRecords.PARQUET_FILE_NAME
+            update_records_path = chunk_dir / UpdateRecords.PARQUET_FILE_NAME
             if update_records_path.exists():
                 blob = self._bucket.blob(f"{gcs_prefix}/{UpdateRecords.PARQUET_FILE_NAME}")
                 blob.upload_from_filename(str(update_records_path))
@@ -175,7 +176,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         and then truncating them. This gives BigQuery the correct schema.
         """
         for table_name, prod_ref in zip(_TABLE_NAMES, self._table_refs.prod, strict=True):
-            parquet_path = chunk.directory / f"{table_name}.parquet"
+            parquet_path = self.ppdb.config.chunk_dir(chunk.id) / f"{table_name}.parquet"
             if parquet_path.exists():
                 self._load_parquet_to_table(parquet_path, prod_ref)
                 self.bq_client.query(f"TRUNCATE TABLE `{prod_ref}`").result()
@@ -186,7 +187,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         This mocks the cloud function which stages the data using Dataflow.
         """
         for table_name, staging_ref in zip(_TABLE_NAMES, self._table_refs.staging, strict=True):
-            parquet_path = chunk.directory / f"{table_name}.parquet"
+            parquet_path = self.ppdb.config.chunk_dir(chunk.id) / f"{table_name}.parquet"
             if parquet_path.exists():
                 self._load_parquet_to_table(parquet_path, staging_ref)
                 self.bq_client.query(
@@ -214,7 +215,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         """Read update records from chunk parquet files and expand them."""
         expanded: list[ExpandedUpdateRecord] = []
         for chunk in self.ppdb.query_chunks():
-            update_path = chunk.directory / UpdateRecords.PARQUET_FILE_NAME
+            update_path = self.ppdb.config.chunk_dir(chunk.id) / UpdateRecords.PARQUET_FILE_NAME
             if update_path.exists():
                 update_records = UpdateRecords.from_parquet_file(update_path)
                 expanded.extend(UpdateRecordExpander.expand_updates(update_records, chunk.id))

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -127,7 +127,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
             chunk_dir = self.ppdb.config.chunk_dir(chunk.id)
             manifest = Manifest.from_json_file(chunk_dir / Manifest.FILE_NAME)
             status = ChunkStatus.UPLOADED if manifest.has_table_data() else ChunkStatus.STAGED
-            gcs_prefix = f"data/test/{chunk.id}"
+            gcs_prefix = self.ppdb.config.chunk_object_prefix(chunk.id)
             gcs_uri = f"gs://{bucket_name}/{gcs_prefix}"
 
             update_records_path = chunk_dir / UpdateRecords.PARQUET_FILE_NAME

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -79,18 +79,15 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         """Test that the update records are correctly uploaded to Google Cloud
         Storage after replication.
         """
-        # Configure and run the uploader.
+        # Configure and run the uploader with a patch to avoid posting to the
+        # stage chunk topic.
         with patch.object(ChunkUploader, "_post_to_stage_chunk_topic"):
-            uploader = ChunkUploader(
+            ChunkUploader(
                 self.ppdb,
                 wait_interval=0,
                 exit_on_empty=True,
                 exit_on_error=True,
-            )
-            print(
-                f"Uploader will copy files to {uploader.config.bucket_name}/{uploader.config.object_prefix}/"
-            )
-            uploader.run()
+            ).run()
 
         # Retrieve the update records file.
         blobs = list(self._bucket.list_blobs(match_glob="**/update_records.parquet"))
@@ -134,16 +131,9 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
 
         self.assertTrue(
             found_match,
-            f"Expected update_records.parquet to be under one of the update chunks, but got {update_records_files}",
+            f"Expected update_records.parquet to be under one of the update chunks, "
+            f"but got {update_records_files}",
         )
-
-        # Verify that none of the uploaded object paths include date directories.
-        for object_name in update_records_files:
-            self.assertNotRegex(
-                object_name,
-                r".*/\d{4}/\d{2}/\d{2}/.*",
-                f"Found unexpected date-directory path in object name: {object_name}",
-            )
 
         manifest_blob = self._bucket.blob(f"{expected_prefix}/{Manifest.FILE_NAME}")
         self.assertTrue(manifest_blob.exists())
@@ -151,9 +141,16 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
 
         local_update_path = self.ppdb.config.chunk_dir(uploaded_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
         expected_checksum = sha256(local_update_path.read_bytes()).hexdigest()
-        self.assertIsNotNone(manifest.updates_data)
-        assert manifest.updates_data is not None
-        self.assertEqual(manifest.updates_data.checksum, expected_checksum)
+        self.assertIsNotNone(
+            manifest.files.get(UpdateRecords.PARQUET_FILE_NAME),
+            "Manifest does not contain update records file entry",
+        )
+        updates_data = manifest.files[UpdateRecords.PARQUET_FILE_NAME]
+        self.assertEqual(
+            updates_data.checksum,
+            expected_checksum,
+            "Checksum of update records file in manifest does not match local file checksum",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -20,12 +20,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from hashlib import sha256
 
 from google.cloud import storage
 
 from lsst.dax.apdb import Apdb, ApdbReplica
 from lsst.dax.ppdb import Ppdb
-from lsst.dax.ppdb.bigquery import PpdbBigQuery
+from lsst.dax.ppdb.bigquery import Manifest, PpdbBigQuery
 from lsst.dax.ppdb.bigquery.updates import UpdateRecords
 from lsst.dax.ppdb.replicator import Replicator
 from lsst.dax.ppdb.tests import fill_apdb
@@ -108,19 +109,47 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
 
         # Verify uploaded objects and chunk gcs_uri use the simplified
         # prefix/chunk_id target path (without date directories).
-        uploaded_chunk = self.ppdb.query_chunks()[0]
-        expected_prefix = f"{self.ppdb.config.object_prefix}/{uploaded_chunk.id}"
-        self.assertEqual(uploaded_chunk.gcs_uri, f"gs://{self.ppdb.config.bucket_name}/{expected_prefix}")
+        # Find the chunk with update records (there should be at least one).
+        chunks_with_updates = [c for c in self.ppdb.query_chunks() if c.update_count > 0]
+        self.assertGreater(
+            len(chunks_with_updates),
+            0,
+            "Expected at least one chunk with update records",
+        )
+
+        # Verify that the uploaded file is under one of the update chunks.
+        found_match = False
+        for uploaded_chunk in chunks_with_updates:
+            expected_prefix = f"{self.ppdb.config.object_prefix}/{uploaded_chunk.id}"
+            self.assertEqual(uploaded_chunk.gcs_uri, f"gs://{self.ppdb.config.bucket_name}/{expected_prefix}")
+
+            for object_name in update_records_files:
+                if object_name.startswith(expected_prefix + "/"):
+                    found_match = True
+                    break
+
+        self.assertTrue(
+            found_match,
+            f"Expected update_records.parquet to be under one of the update chunks, but got {update_records_files}",
+        )
+
+        # Verify that none of the uploaded object paths include date directories.
         for object_name in update_records_files:
-            self.assertTrue(
-                object_name.startswith(expected_prefix + "/"),
-                f"Expected uploaded object '{object_name}' under '{expected_prefix}/'",
-            )
             self.assertNotRegex(
                 object_name,
                 r".*/\d{4}/\d{2}/\d{2}/.*",
                 f"Found unexpected date-directory path in object name: {object_name}",
             )
+
+        manifest_blob = self._bucket.blob(f"{expected_prefix}/{Manifest.FILE_NAME}")
+        self.assertTrue(manifest_blob.exists())
+        manifest = Manifest.from_json_str(manifest_blob.download_as_text())
+
+        local_update_path = self.ppdb.config.chunk_dir(uploaded_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
+        expected_checksum = sha256(local_update_path.read_bytes()).hexdigest()
+        self.assertIsNotNone(manifest.updates_data)
+        assert manifest.updates_data is not None
+        self.assertEqual(manifest.updates_data.checksum, expected_checksum)
 
 
 if __name__ == "__main__":

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -21,17 +21,18 @@
 
 import unittest
 from hashlib import sha256
+from unittest.mock import patch
 
 from google.cloud import storage
 
 from lsst.dax.apdb import Apdb, ApdbReplica
 from lsst.dax.ppdb import Ppdb
 from lsst.dax.ppdb.bigquery import Manifest, PpdbBigQuery
+from lsst.dax.ppdb.bigquery.chunk_uploader import ChunkUploader
 from lsst.dax.ppdb.bigquery.updates import UpdateRecords
 from lsst.dax.ppdb.replicator import Replicator
 from lsst.dax.ppdb.tests import fill_apdb
 from lsst.dax.ppdb.tests._bigquery import (
-    ChunkUploaderWithoutPubSub,
     PostgresMixin,
     delete_test_bucket,
     generate_test_bucket_name,
@@ -79,14 +80,17 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         Storage after replication.
         """
         # Configure and run the uploader.
-        uploader = ChunkUploaderWithoutPubSub(
-            self.ppdb,
-            wait_interval=0,
-            exit_on_empty=True,
-            exit_on_error=True,
-        )
-        print(f"Uploader will copy files to {uploader.config.bucket_name}/{uploader.config.object_prefix}/")
-        uploader.run()
+        with patch.object(ChunkUploader, "_post_to_stage_chunk_topic"):
+            uploader = ChunkUploader(
+                self.ppdb,
+                wait_interval=0,
+                exit_on_empty=True,
+                exit_on_error=True,
+            )
+            print(
+                f"Uploader will copy files to {uploader.config.bucket_name}/{uploader.config.object_prefix}/"
+            )
+            uploader.run()
 
         # Retrieve the update records file.
         blobs = list(self._bucket.list_blobs(match_glob="**/update_records.parquet"))

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -19,8 +19,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import hashlib
 import unittest
-from hashlib import sha256
 from unittest.mock import patch
 
 from google.cloud import storage
@@ -118,34 +118,38 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
             "Expected at least one chunk with update records",
         )
 
-        # Verify that the uploaded file is under one of the update chunks.
-        found_match = False
+        # Verify that the uploaded file is under one of the update chunks, and
+        # select the matching chunk for subsequent manifest/checksum
+        # assertions.
+        matched_chunk = None
+        expected_prefix = None
         for uploaded_chunk in chunks_with_updates:
-            expected_prefix = f"{self.ppdb.config.object_prefix}/{uploaded_chunk.id}"
-            self.assertEqual(uploaded_chunk.gcs_uri, f"gs://{self.ppdb.config.bucket_name}/{expected_prefix}")
+            prefix = f"{self.ppdb.config.object_prefix}/{uploaded_chunk.id}"
+            self.assertEqual(uploaded_chunk.gcs_uri, f"gs://{self.ppdb.config.bucket_name}/{prefix}")
 
-            for object_name in update_records_files:
-                if object_name.startswith(expected_prefix + "/"):
-                    found_match = True
-                    break
+            if any(object_name.startswith(prefix + "/") for object_name in update_records_files):
+                matched_chunk = uploaded_chunk
+                expected_prefix = prefix
+                break
 
-        self.assertTrue(
-            found_match,
-            f"Expected update_records.parquet to be under one of the update chunks, "
-            f"but got {update_records_files}",
+        self.assertIsNotNone(
+            matched_chunk,
+            f"Expected update_records.parquet to be under one of the update chunks, but got "
+            f"{update_records_files}",
         )
 
         manifest_blob = self._bucket.blob(f"{expected_prefix}/{Manifest.FILE_NAME}")
         self.assertTrue(manifest_blob.exists())
         manifest = Manifest.from_json_str(manifest_blob.download_as_text())
 
-        local_update_path = self.ppdb.config.chunk_dir(uploaded_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
-        expected_checksum = sha256(local_update_path.read_bytes()).hexdigest()
         self.assertIsNotNone(
             manifest.files.get(UpdateRecords.PARQUET_FILE_NAME),
             "Manifest does not contain update records file entry",
         )
+
         updates_data = manifest.files[UpdateRecords.PARQUET_FILE_NAME]
+        local_update_path = self.ppdb.config.chunk_dir(uploaded_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
+        expected_checksum = hashlib.sha256(local_update_path.read_bytes()).hexdigest()
         self.assertEqual(
             updates_data.checksum,
             expected_checksum,

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -106,6 +106,22 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
             f"Expected 3 update records in the file from GCS, found {len(update_records.records)}",
         )
 
+        # Verify uploaded objects and chunk gcs_uri use the simplified
+        # prefix/chunk_id target path (without date directories).
+        uploaded_chunk = self.ppdb.query_chunks()[0]
+        expected_prefix = f"{self.ppdb.config.object_prefix}/{uploaded_chunk.id}"
+        self.assertEqual(uploaded_chunk.gcs_uri, f"gs://{self.ppdb.config.bucket_name}/{expected_prefix}")
+        for object_name in update_records_files:
+            self.assertTrue(
+                object_name.startswith(expected_prefix + "/"),
+                f"Expected uploaded object '{object_name}' under '{expected_prefix}/'",
+            )
+            self.assertNotRegex(
+                object_name,
+                r".*/\d{4}/\d{2}/\d{2}/.*",
+                f"Found unexpected date-directory path in object name: {object_name}",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -75,3 +75,32 @@ class ManifestTestCase(unittest.TestCase):
             },
         )
         self.assertFalse(manifest_non_empty.is_empty_chunk())
+
+    def test_parquet_file_stats_roundtrip(self) -> None:
+        """Test that checksum and size_bytes are preserved through JSON roundtrip."""
+        manifest = Manifest(
+            replica_chunk_id="12345",
+            unique_id="550e8400-e29b-41d4-a716-446655440000",
+            schema_version="1.0",
+            exported_at="2025-12-17 07:03:09.991638+00:00",
+            last_update_time="1765951277.036",
+            compression_format="snappy",
+            table_data={
+                "DiaObject": {"row_count": 10, "checksum": "a" * 64, "size_bytes": 4096},
+                "DiaSource": {"row_count": 1, "checksum": "b" * 64, "size_bytes": 512},
+                "DiaForcedSource": {"row_count": 0, "checksum": None, "size_bytes": None},
+            },
+            update_count=1,
+            updates_data={"row_count": 1, "checksum": "c" * 64, "size_bytes": 256},
+        )
+
+        loaded = Manifest.from_json_str(manifest.model_dump_json())
+        self.assertEqual(loaded.table_data["DiaObject"].checksum, "a" * 64)
+        self.assertEqual(loaded.table_data["DiaObject"].size_bytes, 4096)
+        self.assertEqual(loaded.table_data["DiaSource"].checksum, "b" * 64)
+        self.assertEqual(loaded.table_data["DiaSource"].size_bytes, 512)
+        self.assertIsNone(loaded.table_data["DiaForcedSource"].checksum)
+        self.assertIsNone(loaded.table_data["DiaForcedSource"].size_bytes)
+        assert loaded.updates_data is not None
+        self.assertEqual(loaded.updates_data.checksum, "c" * 64)
+        self.assertEqual(loaded.updates_data.size_bytes, 256)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -21,86 +21,83 @@
 
 import unittest
 
-from lsst.dax.ppdb.bigquery.manifest import Manifest
+from lsst.dax.ppdb.bigquery import Manifest, ParquetFileEntry
+from lsst.dax.ppdb.bigquery.updates.update_records import UpdateRecords
 
 
 class ManifestTestCase(unittest.TestCase):
     """A test case for the Manifest class."""
 
+    @staticmethod
+    def _create_manifest_with_files(file_names: list[str]):
+        return Manifest(
+            replica_chunk_id="12345",
+            unique_id="550e8400-e29b-41d4-a716-446655440000",
+            schema_version="1.0",
+            exported_at="2025-12-17 07:03:09.991638+00:00",
+            last_update_time="1765951277.036",
+            files={name: {"row_count": 10} for name in file_names},
+            compression_format="snappy",
+        )
+
     def test_is_empty_chunk(self):
         """Test the is_empty_chunk method of the Manifest class."""
-        manifest = Manifest(
-            replica_chunk_id="12345",
-            unique_id="550e8400-e29b-41d4-a716-446655440000",
-            schema_version="1.0",
-            exported_at="2025-12-17 07:03:09.991638+00:00",
-            last_update_time="1765951277.036",
-            compression_format="snappy",
-            table_data={
-                "DiaObject": {"row_count": 0},
-                "DiaSource": {"row_count": 0},
-                "DiaForcedSource": {"row_count": 0},
-            },
-        )
-        self.assertTrue(manifest.is_empty_chunk())
+        # A manifest with no files should be considered empty.
+        manifest_no_files = self._create_manifest_with_files([])
+        self.assertTrue(manifest_no_files.is_empty_chunk)
 
-        # A manifest with update_count > 0 should not be empty.
-        manifest_with_updates = Manifest(
-            replica_chunk_id="12345",
-            unique_id="550e8400-e29b-41d4-a716-446655440000",
-            schema_version="1.0",
-            exported_at="2025-12-17 07:03:09.991638+00:00",
-            last_update_time="1765951277.036",
-            compression_format="snappy",
-            table_data={
-                "DiaObject": {"row_count": 0},
-                "DiaSource": {"row_count": 0},
-                "DiaForcedSource": {"row_count": 0},
-            },
-            update_count=3,
-        )
-        self.assertFalse(manifest_with_updates.is_empty_chunk())
+        # A manifest with updates but no table data should not be considered
+        # empty.
+        manifest_with_updates = self._create_manifest_with_files([UpdateRecords.PARQUET_FILE_NAME])
+        self.assertFalse(manifest_with_updates.is_empty_chunk)
 
-        manifest_non_empty = Manifest(
-            replica_chunk_id="12345",
-            unique_id="550e8400-e29b-41d4-a716-446655440000",
-            schema_version="1.0",
-            exported_at="2025-12-17 07:03:09.991638+00:00",
-            last_update_time="1765951277.036",
-            compression_format="snappy",
-            table_data={
-                "DiaObject": {"row_count": 10},
-                "DiaSource": {"row_count": 10},
-                "DiaForcedSource": {"row_count": 0},
-            },
+        # A manifest with some table data but no updates should not be
+        # considered empty.
+        manifest_non_empty = self._create_manifest_with_files(["DiaObject"])
+        self.assertFalse(manifest_non_empty.is_empty_chunk)
+
+        # A manifest with updates but no table data should not be considered
+        # empty.
+        manifest_with_updates = self._create_manifest_with_files([UpdateRecords.PARQUET_FILE_NAME])
+        self.assertFalse(manifest_with_updates.is_empty_chunk)
+
+        # A manifest with both table data and updates should not be considered
+        # empty.
+        manifest_with_both = self._create_manifest_with_files(
+            ["DiaObject", "DiaSource", "DiaForcedSource", UpdateRecords.PARQUET_FILE_NAME]
         )
-        self.assertFalse(manifest_non_empty.is_empty_chunk())
+        self.assertFalse(manifest_with_both.is_empty_chunk)
 
     def test_parquet_file_stats_roundtrip(self) -> None:
-        """Test that checksum and size_bytes are preserved through JSON roundtrip."""
-        manifest = Manifest(
-            replica_chunk_id="12345",
-            unique_id="550e8400-e29b-41d4-a716-446655440000",
-            schema_version="1.0",
-            exported_at="2025-12-17 07:03:09.991638+00:00",
-            last_update_time="1765951277.036",
-            compression_format="snappy",
-            table_data={
-                "DiaObject": {"row_count": 10, "checksum": "a" * 64, "size_bytes": 4096},
-                "DiaSource": {"row_count": 1, "checksum": "b" * 64, "size_bytes": 512},
-                "DiaForcedSource": {"row_count": 0, "checksum": None, "size_bytes": None},
-            },
-            update_count=1,
-            updates_data={"row_count": 1, "checksum": "c" * 64, "size_bytes": 256},
-        )
+        """Test that the file statistics are preserved through JSON
+        roundtrip.
+        """
+        manifest = self._create_manifest_with_files([])
 
+        manifest.files = {
+            "DiaObject": ParquetFileEntry(row_count=10, checksum="a" * 64, size_bytes=100),
+            "DiaSource": ParquetFileEntry(row_count=1, checksum="b" * 64, size_bytes=200),
+            "DiaForcedSource": ParquetFileEntry(row_count=3, checksum="c" * 64, size_bytes=300),
+            UpdateRecords.PARQUET_FILE_NAME: ParquetFileEntry(row_count=3, checksum="d" * 64, size_bytes=400),
+        }
+
+        # Check that the data loaded from the JSON string matches the original
+        # data.
         loaded = Manifest.from_json_str(manifest.model_dump_json())
-        self.assertEqual(loaded.table_data["DiaObject"].checksum, "a" * 64)
-        self.assertEqual(loaded.table_data["DiaObject"].size_bytes, 4096)
-        self.assertEqual(loaded.table_data["DiaSource"].checksum, "b" * 64)
-        self.assertEqual(loaded.table_data["DiaSource"].size_bytes, 512)
-        self.assertIsNone(loaded.table_data["DiaForcedSource"].checksum)
-        self.assertIsNone(loaded.table_data["DiaForcedSource"].size_bytes)
-        assert loaded.updates_data is not None
-        self.assertEqual(loaded.updates_data.checksum, "c" * 64)
-        self.assertEqual(loaded.updates_data.size_bytes, 256)
+        self.assertEqual(loaded.files["DiaObject"].row_count, 10)
+        self.assertEqual(loaded.files["DiaObject"].checksum, "a" * 64)
+        self.assertEqual(loaded.files["DiaObject"].size_bytes, 100)
+        self.assertEqual(loaded.files["DiaSource"].row_count, 1)
+        self.assertEqual(loaded.files["DiaSource"].checksum, "b" * 64)
+        self.assertEqual(loaded.files["DiaSource"].size_bytes, 200)
+        self.assertEqual(loaded.files["DiaForcedSource"].row_count, 3)
+        self.assertEqual(loaded.files["DiaForcedSource"].checksum, "c" * 64)
+        self.assertEqual(loaded.files["DiaForcedSource"].size_bytes, 300)
+        self.assertEqual(loaded.files[UpdateRecords.PARQUET_FILE_NAME].row_count, 3)
+        self.assertEqual(loaded.files[UpdateRecords.PARQUET_FILE_NAME].checksum, "d" * 64)
+        self.assertEqual(loaded.files[UpdateRecords.PARQUET_FILE_NAME].size_bytes, 400)
+
+    def test_row_count_zero_raises(self) -> None:
+        """Test that a row count of zero raises a ValueError."""
+        with self.assertRaises(ValueError):
+            ParquetFileEntry(row_count=0, checksum="a" * 64, size_bytes=100)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -36,7 +36,7 @@ class ManifestTestCase(unittest.TestCase):
             schema_version="1.0",
             exported_at="2025-12-17 07:03:09.991638+00:00",
             last_update_time="1765951277.036",
-            files={name: {"row_count": 10} for name in file_names},
+            files={name: {"row_count": 10, "checksum": "a" * 64, "size_bytes": 100} for name in file_names},
             compression_format="snappy",
         )
 
@@ -55,11 +55,6 @@ class ManifestTestCase(unittest.TestCase):
         # considered empty.
         manifest_non_empty = self._create_manifest_with_files(["DiaObject"])
         self.assertFalse(manifest_non_empty.is_empty_chunk)
-
-        # A manifest with updates but no table data should not be considered
-        # empty.
-        manifest_with_updates = self._create_manifest_with_files([UpdateRecords.PARQUET_FILE_NAME])
-        self.assertFalse(manifest_with_updates.is_empty_chunk)
 
         # A manifest with both table data and updates should not be considered
         # empty.

--- a/tests/test_ppdb_bigquery.py
+++ b/tests/test_ppdb_bigquery.py
@@ -21,7 +21,6 @@
 
 import unittest
 import uuid
-from pathlib import Path
 
 import astropy.time
 import sqlalchemy
@@ -49,7 +48,6 @@ class PostgresTestCase(PostgresMixin, PpdbTest, unittest.TestCase):
 def _make_chunk(
     chunk_id: int,
     status: ChunkStatus,
-    directory: str = "/tmp/test",
 ) -> PpdbReplicaChunkExtended:
     """Create a test chunk with the given ID and status.
 
@@ -59,13 +57,11 @@ def _make_chunk(
         The ID of the chunk to create.
     status
         The status to assign to the chunk.
-    directory
-        The directory path for the chunk, by default "/tmp/test".
 
     Returns
     -------
     `PpdbReplicaChunkExtended`
-        A test chunk with the specified ID, status, and directory.
+        A test chunk with the specified ID and status.
     """
     return PpdbReplicaChunkExtended(
         id=chunk_id,
@@ -73,7 +69,6 @@ def _make_chunk(
         last_update_time=astropy.time.Time("2021-01-01T00:01:00", format="isot", scale="tai"),
         replica_time=astropy.time.Time.now(),
         status=status,
-        directory=Path(directory),
     )
 
 
@@ -158,10 +153,10 @@ class ReplicaChunkTestCase(SqliteMixin, unittest.TestCase):
             ppdb.update_chunks([_make_chunk(1, ChunkStatus.STAGED)], fields=set())
 
     def test_update_chunks_invalid_fields_raises(self) -> None:
-        """Test that update_chunks raises on invalid field names."""
+        """Test that update_chunks rejects an invalid field name."""
         ppdb = self._make_ppdb()
         with self.assertRaises(ValueError):
-            ppdb.update_chunks([_make_chunk(1, ChunkStatus.STAGED)], fields={"directory"})
+            ppdb.update_chunks([_make_chunk(1, ChunkStatus.STAGED)], fields={"bad_field"})
 
     def test_insert_chunks_duplicate_raises(self) -> None:
         """Test that insert_chunks raises on duplicate chunk ID."""

--- a/tests/test_update_records.py
+++ b/tests/test_update_records.py
@@ -20,6 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from hashlib import sha256
 
 from lsst.dax.apdb import (
     Apdb,
@@ -27,7 +28,7 @@ from lsst.dax.apdb import (
     apdbUpdateRecord,
 )
 from lsst.dax.ppdb import Ppdb
-from lsst.dax.ppdb.bigquery import PpdbBigQuery
+from lsst.dax.ppdb.bigquery import Manifest, PpdbBigQuery
 from lsst.dax.ppdb.bigquery.updates import UpdateRecords
 from lsst.dax.ppdb.replicator import Replicator
 from lsst.dax.ppdb.tests import fill_apdb
@@ -66,10 +67,17 @@ class UpdateRecordsTestCase(PostgresMixin, unittest.TestCase):
         file in the replication output and can be read back as valid
         UpdateRecords objects.
         """
-        update_records_path = (
-            self.ppdb.config.chunk_dir(1614600000) / UpdateRecords.PARQUET_FILE_NAME
-        )
+        update_records_path = (self.ppdb.config.chunk_dir(1614600000) / UpdateRecords.PARQUET_FILE_NAME)
         self.assertTrue(update_records_path.exists(), "Update records file not found in replication output")
+
+        manifest = Manifest.from_json_file(self.ppdb.config.chunk_dir(1614600000) / Manifest.FILE_NAME)
+        file_bytes = update_records_path.read_bytes()
+        expected_checksum = sha256(file_bytes).hexdigest()
+        expected_size = len(file_bytes)
+        self.assertIsNotNone(manifest.updates_data)
+        assert manifest.updates_data is not None
+        self.assertEqual(manifest.updates_data.checksum, expected_checksum)
+        self.assertEqual(manifest.updates_data.size_bytes, expected_size)
 
         update_records = UpdateRecords.from_parquet_file(update_records_path)
 

--- a/tests/test_update_records.py
+++ b/tests/test_update_records.py
@@ -67,17 +67,20 @@ class UpdateRecordsTestCase(PostgresMixin, unittest.TestCase):
         file in the replication output and can be read back as valid
         UpdateRecords objects.
         """
-        update_records_path = (self.ppdb.config.chunk_dir(1614600000) / UpdateRecords.PARQUET_FILE_NAME)
+        update_records_path = self.ppdb.config.chunk_dir(1614600000) / UpdateRecords.PARQUET_FILE_NAME
         self.assertTrue(update_records_path.exists(), "Update records file not found in replication output")
 
         manifest = Manifest.from_json_file(self.ppdb.config.chunk_dir(1614600000) / Manifest.FILE_NAME)
         file_bytes = update_records_path.read_bytes()
         expected_checksum = sha256(file_bytes).hexdigest()
         expected_size = len(file_bytes)
-        self.assertIsNotNone(manifest.updates_data)
-        assert manifest.updates_data is not None
-        self.assertEqual(manifest.updates_data.checksum, expected_checksum)
-        self.assertEqual(manifest.updates_data.size_bytes, expected_size)
+        self.assertTrue(manifest.has_update_records, "Manifest should have update records")
+        self.assertIn(
+            UpdateRecords.PARQUET_FILE_NAME, manifest.files, "Update records file not found in manifest"
+        )
+        updates_data = manifest.files[UpdateRecords.PARQUET_FILE_NAME]
+        self.assertEqual(updates_data.checksum, expected_checksum)
+        self.assertEqual(updates_data.size_bytes, expected_size)
 
         update_records = UpdateRecords.from_parquet_file(update_records_path)
 

--- a/tests/test_update_records.py
+++ b/tests/test_update_records.py
@@ -67,7 +67,7 @@ class UpdateRecordsTestCase(PostgresMixin, unittest.TestCase):
         UpdateRecords objects.
         """
         update_records_path = (
-            self.ppdb.config.replication_path / "2021/03/01/1614600000" / "update_records.parquet"
+            self.ppdb.config.replication_path / "1614600000" / "update_records.parquet"
         )
         self.assertTrue(update_records_path.exists(), "Update records file not found in replication output")
 

--- a/tests/test_update_records.py
+++ b/tests/test_update_records.py
@@ -67,7 +67,7 @@ class UpdateRecordsTestCase(PostgresMixin, unittest.TestCase):
         UpdateRecords objects.
         """
         update_records_path = (
-            self.ppdb.config.replication_path / "1614600000" / "update_records.parquet"
+            self.ppdb.config.chunk_dir(1614600000) / UpdateRecords.PARQUET_FILE_NAME
         )
         self.assertTrue(update_records_path.exists(), "Update records file not found in replication output")
 

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -239,13 +239,12 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
 
         # Configure and run the uploader without publishing to Pub/Sub.
         with patch.object(ChunkUploader, "_post_to_stage_chunk_topic"):
-            uploader = ChunkUploader(
+            ChunkUploader(
                 self.ppdb,
                 wait_interval=0,
                 exit_on_empty=True,
                 exit_on_error=True,
-            )
-            uploader.run()
+            ).run()
 
         # Apply the updates to the target tables using the UpdatesManager.
         updates_manager = UpdatesManager(self.ppdb.config)

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -22,6 +22,7 @@
 import unittest
 import uuid
 from collections.abc import Collection, Sequence
+from unittest.mock import patch
 
 import astropy
 import felis
@@ -33,9 +34,9 @@ from lsst.dax.apdb import (
 )
 from lsst.dax.ppdb import Ppdb
 from lsst.dax.ppdb.bigquery import PpdbBigQuery
+from lsst.dax.ppdb.bigquery.chunk_uploader import ChunkUploader
 from lsst.dax.ppdb.bigquery.updates.updates_manager import UpdatesManager
 from lsst.dax.ppdb.tests._bigquery import (
-    ChunkUploaderWithoutPubSub,
     PostgresMixin,
     generate_test_bucket_name,
     have_valid_google_credentials,
@@ -237,13 +238,14 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         )
 
         # Configure and run the uploader without publishing to Pub/Sub.
-        uploader = ChunkUploaderWithoutPubSub(
-            self.ppdb,
-            wait_interval=0,
-            exit_on_empty=True,
-            exit_on_error=True,
-        )
-        uploader.run()
+        with patch.object(ChunkUploader, "_post_to_stage_chunk_topic"):
+            uploader = ChunkUploader(
+                self.ppdb,
+                wait_interval=0,
+                exit_on_empty=True,
+                exit_on_error=True,
+            )
+            uploader.run()
 
         # Apply the updates to the target tables using the UpdatesManager.
         updates_manager = UpdatesManager(self.ppdb.config)


### PR DESCRIPTION
This PR implements a number of miscellaneous improvements to the `ppdb_bigquery` module and related classes used for replication and data ingestion.

**Removed certain use of dates in chunk tracking**

The date was removed from naming of the local directory which contains parquet files for upload. Now, only the replica chunk ID is used, as this simplifies directory management, so the local directory will be something like `{config.replication_dir}/123456`. This simplifies finding a given chunk's data, as its directory can be easily found by convention using only the chunk ID and the replication directory from the config.
 
The use of dates was also removed from the names of cloud storage object paths, which now use only the replica chunk ID after the standard prefix (e.g., `chunks`). A new cloud storage path might look like: `gcs://ppdb-some-bucket/chunks/12345/DiaObject.parquet`. This will simplify usage of globs for object management and querying using the Google Cloud API.

The `chunk_dir` field was removed from the `PpdbBigQuery` version of the `PpdbReplicaChunk` table, as it should no longer be necessary given the above changes.

**Restructured the JSON manifest and added additional ifile nformation**

The `Manifest` model used for keeping track of metadata for files in cloud storage was updated to include a SHA-256 checksum of each parquet file, as well as the file's size in bytes. The `TableStats` model was renamed to `ParquetFileStats` and the key from `table_data` to `files`. The parquet file containing update records was included as a standard file entry. Non-existent files will not have entries in the manifest (absence indicates they were not written by the replication for that chunk).

**Minor Changes**

The `ChunkUploaderWithoutPubSub` class was removed from the test utilities and replaced with a mock patch in the two tests where it was used.

The bucket name was added to the logging in `chunk_uploader` when copying sets of files to GCS.