### PR TITLE
DM-54681: Use multiple datasets from PPDB configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,3 +166,7 @@ convention = "numpy"
 # D200, D205 and D400 all complain if the first sentence of the docstring does
 # not fit on one line. We do not require docstrings in __init__ files (D104).
 add-ignore = ["D107", "D105", "D102", "D100", "D200", "D205", "D400", "D104"]
+
+[tool.pyright]
+include = ["python", "tests"]
+extraPaths = ["python"]

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -36,13 +36,12 @@ from google.cloud import bigquery
 from lsst.dax.apdb import ApdbTables
 
 from .ppdb_bigquery import PpdbBigQuery
-from .ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
+from .ppdb_bigquery_config import PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .query_runner import QueryRunner
 from .sql_resource import SqlResource
+from .table_refs import TableRefs
 from .updates.updates_manager import UpdatesManager
-
-_PROMOTED_TMP_SUFFIX = "_promoted_tmp"
 
 
 class NoPromotableChunksError(Exception):
@@ -74,6 +73,8 @@ class ChunkPromoter:
         ApdbTables.DiaForcedSource.value,
     )
 
+    _PROMOTED_TMP_SUFFIX = "_promoted_tmp"
+
     def __init__(
         self,
         ppdb: PpdbBigQuery,
@@ -81,13 +82,13 @@ class ChunkPromoter:
     ):
         self._ppdb = ppdb
 
-        # FIXME: This should be changed to accept the location and not the
-        # dataset.
         self._runner = QueryRunner(self.config.project_id, self.config.datasets.internal)
 
         self._table_names = tuple(table_names) if table_names is not None else self._DEFAULT_TABLE_NAMES
         if len(self._table_names) == 0:
             raise ChunkPromotionError("table_names must not be empty")
+
+        self._table_refs = TableRefs(self.config)
 
         self._bq_client = bigquery.Client(project=self.config.project_id)
 
@@ -106,9 +107,21 @@ class ChunkPromoter:
         return self._promotable_chunks
 
     @property
+    def table_refs(self) -> TableRefs:
+        """Table references (`TableRefs`, read-only)."""
+        return self._table_refs
+
+    @property
     def table_names(self) -> tuple[str, ...]:
         """Table names to promote (`tuple` [`str`], read-only)."""
         return self._table_names
+
+    @classmethod
+    def _promoted_tmp_name(cls, table_name: str) -> str:
+        """Return the promoted temporary table name for a given base table
+        name.
+        """
+        return f"{table_name}{cls._PROMOTED_TMP_SUFFIX}"
 
     def promote_chunks(self, chunks: list[PpdbReplicaChunkExtended]) -> None:
         """Promote APDB replica chunks into production by executing a series of
@@ -181,9 +194,9 @@ class ChunkPromoter:
         for table_name in self.table_names:
             # Build fully qualified table names which will be used in the
             # queries.
-            staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, table_name)
-            internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name)
-            tmp_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
+            staging_table_fqn = self.table_refs.staging(table_name)
+            internal_table_fqn = self.table_refs.internal(table_name)
+            tmp_table_fqn = self.table_refs.internal(self._promoted_tmp_name(table_name))
 
             # Drop existing promoted tmp table, if it exists.
             self._runner.run_job("drop_tmp", f"DROP TABLE IF EXISTS `{tmp_table_fqn}`")
@@ -192,7 +205,7 @@ class ChunkPromoter:
             self._runner.run_job("clone_prod", f"CREATE TABLE `{tmp_table_fqn}` CLONE `{internal_table_fqn}`")
 
             # Build target column list for SQL statement from the internal
-            # table's schema.
+            # table's schema. This will include the geo_point column.
             target_schema = self._bq_client.get_table(internal_table_fqn).schema
             target_names = [target_column.name for target_column in target_schema]
             target_list_sql = ", ".join(f"`{column_name}`" for column_name in target_names)
@@ -204,9 +217,8 @@ class ChunkPromoter:
                 for column_name in target_names
             )
 
-            # Insert staged rows into the promoted tmp table. If staging does
-            # not match the internal table schema, this will fail with a schema
-            # mismatch error.
+            # Insert staged rows into the promoted tmp table. If the staging
+            # and internal schemas do not match, this will fail.
             sql = f"""
             INSERT INTO `{tmp_table_fqn}` ({target_list_sql})
             SELECT {source_list_sql}
@@ -220,7 +232,7 @@ class ChunkPromoter:
         """Apply record updates to the promoted temporary tables."""
         updates_manager = UpdatesManager(
             self._ppdb.config,
-            table_name_format="{}" + _PROMOTED_TMP_SUFFIX,
+            table_name_format="{}" + self._PROMOTED_TMP_SUFFIX,
         )
 
         # Apply the updates for the chunks. The manager will skip the process
@@ -234,11 +246,11 @@ class ChunkPromoter:
         """
         job_name = "fill_diaobject_validity_end"
 
-        target_table = ApdbTables.DiaObject.value + _PROMOTED_TMP_SUFFIX
-        target_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, target_table)
+        target_table = self._promoted_tmp_name(ApdbTables.DiaObject.value)
+        target_table_fqn = self.table_refs.internal(target_table)
 
         staging_table = ApdbTables.DiaObject.value
-        staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, staging_table)
+        staging_table_fqn = self.table_refs.staging(staging_table)
 
         sql = SqlResource(
             job_name,
@@ -268,8 +280,8 @@ class ChunkPromoter:
         dataset.
         """
         for table_name in self.table_names:
-            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
-            prod_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name)
+            tmp_ref = self.table_refs.internal(self._promoted_tmp_name(table_name))
+            prod_ref = self.table_refs.internal(table_name)
 
             # Ensure tmp exists.
             try:
@@ -296,15 +308,17 @@ class ChunkPromoter:
         )
 
         for table_name in self.table_names:
-            staging_ref = self.config.fqn_for(DatasetType.STAGING, table_name)
+            staging_table_fqn = self.table_refs.staging(table_name)
             try:
-                sql = f"DELETE FROM `{staging_ref}` WHERE apdb_replica_chunk IN UNNEST(@ids)"
+                sql = f"DELETE FROM `{staging_table_fqn}` WHERE apdb_replica_chunk IN UNNEST(@ids)"
                 self._runner.run_job("delete_staged_chunks", sql, job_config=job_config)
                 logging.debug(
-                    "Deleted %d chunk(s) from staging table %s", len(self.promotable_chunks), staging_ref
+                    "Deleted %d chunk(s) from staging table %s",
+                    len(self.promotable_chunks),
+                    staging_table_fqn,
                 )
             except NotFound:
-                logging.warning("Staging table %s does not exist, skipping delete", staging_ref)
+                logging.warning("Staging table %s does not exist, skipping delete", staging_table_fqn)
 
     def _mark_chunks_promoted(self) -> None:
         """Mark the replica chunks as promoted in the database."""
@@ -315,7 +329,7 @@ class ChunkPromoter:
         """Cleanup state after executing the promotion."""
         # Delete the tmp tables.
         for table_name in self.table_names:
-            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
+            tmp_ref = self.table_refs.internal(self._promoted_tmp_name(table_name))
             self._bq_client.delete_table(tmp_ref, not_found_ok=True)
             logging.debug("Dropped %s (if it existed)", tmp_ref)
 

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -313,7 +313,7 @@ class ChunkPromoter:
     def _cleanup(self) -> None:
         """Cleanup state after executing the promotion."""
         # Delete the tmp tables.
-        for table_name in self._DEFAULT_TABLE_NAMES:
+        for table_name in self.table_names:
             tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
             self._bq_client.delete_table(tmp_ref, not_found_ok=True)
             logging.debug("Dropped %s (if it existed)", tmp_ref)

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -168,7 +168,7 @@ class ChunkPromoter:
         logging.info("Completed promotion of %d chunk(s)", len(chunks))
 
     def _copy_to_promoted_tmp(self) -> None:
-        """Build a temporary tables by cloning the current prod tables and
+        """Build temporary tables by cloning the current prod tables and
         inserting staged rows for the promotable chunks.
         """
         job_cfg = bigquery.QueryJobConfig(

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -28,6 +28,7 @@ __all__ = [
 ]
 
 import logging
+from collections.abc import Sequence
 
 from google.api_core.exceptions import NotFound
 from google.cloud import bigquery
@@ -64,19 +65,19 @@ class ChunkPromoter:
     ppdb
         Interface to the PPDB in BigQuery.
     table_names
-        List of table names to promote or if None a default list will be used.
+        Table names to promote or None to use a default set.
     """
 
-    _DEFAULT_TABLE_NAMES = [
+    _DEFAULT_TABLE_NAMES = (
         ApdbTables.DiaObject.value,
         ApdbTables.DiaSource.value,
         ApdbTables.DiaForcedSource.value,
-    ]
+    )
 
     def __init__(
         self,
         ppdb: PpdbBigQuery,
-        table_names: list[str] | None = None,
+        table_names: Sequence[str] | None = None,
     ):
         self._ppdb = ppdb
 
@@ -84,7 +85,7 @@ class ChunkPromoter:
         # dataset.
         self._runner = QueryRunner(self.config.project_id, self.config.datasets.internal)
 
-        self._table_names = table_names if table_names is not None else self._DEFAULT_TABLE_NAMES
+        self._table_names = tuple(table_names) if table_names is not None else self._DEFAULT_TABLE_NAMES
         if len(self._table_names) == 0:
             raise ChunkPromotionError("table_names must not be empty")
 
@@ -105,8 +106,8 @@ class ChunkPromoter:
         return self._promotable_chunks
 
     @property
-    def table_names(self) -> list[str]:
-        """List of table names to promote (`list` [`str`], read-only)."""
+    def table_names(self) -> tuple[str, ...]:
+        """Table names to promote (`tuple` [`str`], read-only)."""
         return self._table_names
 
     def promote_chunks(self, chunks: list[PpdbReplicaChunkExtended]) -> None:

--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -35,12 +35,13 @@ from google.cloud import bigquery
 from lsst.dax.apdb import ApdbTables
 
 from .ppdb_bigquery import PpdbBigQuery
-from .ppdb_bigquery_config import PpdbBigQueryConfig
+from .ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .query_runner import QueryRunner
 from .sql_resource import SqlResource
-from .table_refs import TableRefs
 from .updates.updates_manager import UpdatesManager
+
+_PROMOTED_TMP_SUFFIX = "_promoted_tmp"
 
 
 class NoPromotableChunksError(Exception):
@@ -78,15 +79,16 @@ class ChunkPromoter:
         table_names: list[str] | None = None,
     ):
         self._ppdb = ppdb
-        self._runner = QueryRunner(self.config.project_id, self.config.dataset_id)
-        self._table_names = table_names if table_names is not None else self._DEFAULT_TABLE_NAMES
-        self._bq_client = bigquery.Client(project=self.config.project_id)
 
-        self._table_refs = TableRefs(
-            project_id=self.config.project_id,
-            dataset_id=self.config.dataset_id,
-            table_names=tuple(self._table_names),
-        )
+        # FIXME: This should be changed to accept the location and not the
+        # dataset.
+        self._runner = QueryRunner(self.config.project_id, self.config.datasets.internal)
+
+        self._table_names = table_names if table_names is not None else self._DEFAULT_TABLE_NAMES
+        if len(self._table_names) == 0:
+            raise ChunkPromotionError("table_names must not be empty")
+
+        self._bq_client = bigquery.Client(project=self.config.project_id)
 
         self._promotable_chunks: list[PpdbReplicaChunkExtended] = []
 
@@ -103,13 +105,13 @@ class ChunkPromoter:
         return self._promotable_chunks
 
     @property
-    def table_refs(self) -> TableRefs:
-        """Table references (`TableRefs`, read-only)."""
-        return self._table_refs
+    def table_names(self) -> list[str]:
+        """List of table names to promote (`list` [`str`], read-only)."""
+        return self._table_names
 
     def promote_chunks(self, chunks: list[PpdbReplicaChunkExtended]) -> None:
         """Promote APDB replica chunks into production by executing a series of
-        phases.
+        steps in BigQuery.
 
         Parameters
         ----------
@@ -121,7 +123,7 @@ class ChunkPromoter:
         ------
         ChunkPromotionError
             Raised if any error occurs during execution of the promotion
-            phases.
+            steps in BigQuery.
         NoPromotableChunksError
             Raised if ``chunks`` is empty.
         """
@@ -166,8 +168,8 @@ class ChunkPromoter:
         logging.info("Completed promotion of %d chunk(s)", len(chunks))
 
     def _copy_to_promoted_tmp(self) -> None:
-        """Build ``_{table_name}_promoted_tmp`` efficiently by cloning prod and
-        inserting only staged rows for the given replica chunk IDs.
+        """Build a temporary tables by cloning the current prod tables and
+        inserting staged rows for the promotable chunks.
         """
         job_cfg = bigquery.QueryJobConfig(
             query_parameters=[
@@ -175,41 +177,49 @@ class ChunkPromoter:
             ]
         )
 
-        for prod_ref, tmp_ref, stage_ref in zip(
-            self._table_refs.prod, self._table_refs.promoted_tmp, self._table_refs.staging, strict=True
-        ):
-            # Drop any existing tmp table (should not exist but just to be
-            # safe).
-            self._runner.run_job("drop_tmp", f"DROP TABLE IF EXISTS `{tmp_ref}`")
+        for table_name in self.table_names:
+            # Build fully qualified table names which will be used in the
+            # queries.
+            staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, table_name)
+            internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name)
+            tmp_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
+
+            # Drop existing promoted tmp table, if it exists.
+            self._runner.run_job("drop_tmp", f"DROP TABLE IF EXISTS `{tmp_table_fqn}`")
 
             # Clone prod table structure and data (zero-copy).
-            self._runner.run_job("clone_prod", f"CREATE TABLE `{tmp_ref}` CLONE `{prod_ref}`")
+            self._runner.run_job("clone_prod", f"CREATE TABLE `{tmp_table_fqn}` CLONE `{internal_table_fqn}`")
 
-            # Build ordered target list from the cloned tmp schema.
-            tmp_schema = self._bq_client.get_table(tmp_ref).schema
-            target_names = [f.name for f in tmp_schema if f.name != "apdb_replica_chunk"]
-            target_list_sql = ", ".join(f"`{n}`" for n in target_names)
+            # Build target column list for SQL statement from the internal
+            # table's schema.
+            target_schema = self._bq_client.get_table(internal_table_fqn).schema
+            target_names = [target_column.name for target_column in target_schema]
+            target_list_sql = ", ".join(f"`{column_name}`" for column_name in target_names)
 
-            # Build source list, handling geo_point conversion.
+            # Build source column list for SQL statement from the target list,
+            # converting ra/dec to ST_GEOGPOINT for geo_point column.
             source_list_sql = ", ".join(
-                "ST_GEOGPOINT(s.`ra`, s.`dec`)" if n == "geo_point" else f"s.`{n}`" for n in target_names
+                "ST_GEOGPOINT(s.`ra`, s.`dec`)" if column_name == "geo_point" else f"s.`{column_name}`"
+                for column_name in target_names
             )
 
-            # Insert staged rows into tmp, excluding apdb_replica_chunk column.
+            # Insert staged rows into the promoted tmp table. If staging does
+            # not match the internal table schema, this will fail with a schema
+            # mismatch error.
             sql = f"""
-            INSERT INTO `{tmp_ref}` ({target_list_sql})
+            INSERT INTO `{tmp_table_fqn}` ({target_list_sql})
             SELECT {source_list_sql}
-            FROM `{stage_ref}` AS s
+            FROM `{staging_table_fqn}` AS s
             WHERE s.apdb_replica_chunk IN UNNEST(@ids)
             """
-            logging.debug("SQL for inserting staged rows into %s: %s", tmp_ref, sql)
+            logging.debug("SQL for inserting staged rows into %s: %s", tmp_table_fqn, sql)
             self._runner.run_job("insert_staged_to_tmp", sql, job_config=job_cfg)
 
     def _apply_record_updates(self) -> None:
         """Apply record updates to the promoted temporary tables."""
         updates_manager = UpdatesManager(
             self._ppdb.config,
-            table_name_format=self._table_refs.promoted_tmp_format,
+            table_name_format="{}" + _PROMOTED_TMP_SUFFIX,
         )
 
         # Apply the updates for the chunks. The manager will skip the process
@@ -223,11 +233,11 @@ class ChunkPromoter:
         """
         job_name = "fill_diaobject_validity_end"
 
-        target_table = self._table_refs.promoted_tmp_format.format(ApdbTables.DiaObject.value)
-        target_table_fqn = f"{self.config.dataset_id}.{target_table}"
+        target_table = ApdbTables.DiaObject.value + _PROMOTED_TMP_SUFFIX
+        target_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, target_table)
 
-        staging_table = self._table_refs.staging_format.format(ApdbTables.DiaObject.value)
-        staging_table_fqn = f"{self.config.dataset_id}.{staging_table}"
+        staging_table = ApdbTables.DiaObject.value
+        staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, staging_table)
 
         sql = SqlResource(
             job_name,
@@ -256,14 +266,17 @@ class ChunkPromoter:
         schema, partitioning, and clustering with zero-copy when in the same
         dataset.
         """
-        for prod_ref, tmp_ref in zip(self._table_refs.prod, self._table_refs.promoted_tmp, strict=True):
+        for table_name in self.table_names:
+            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
+            prod_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name)
+
             # Ensure tmp exists.
             try:
                 self._bq_client.get_table(tmp_ref)
             except NotFound as e:
                 raise RuntimeError(f"Missing tmp table for promotion: {tmp_ref}") from e
 
-            # Perform an atomic, zero-copy replacement of prod with tmp.
+            # Perform an atomic, zero-copy replacement of prod with temp.
             copy_cfg = bigquery.CopyJobConfig(write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE)
             job = self._bq_client.copy_table(
                 tmp_ref, prod_ref, job_config=copy_cfg, location=self._runner.location
@@ -281,7 +294,8 @@ class ChunkPromoter:
             ]
         )
 
-        for staging_ref in self._table_refs.staging:
+        for table_name in self.table_names:
+            staging_ref = self.config.fqn_for(DatasetType.STAGING, table_name)
             try:
                 sql = f"DELETE FROM `{staging_ref}` WHERE apdb_replica_chunk IN UNNEST(@ids)"
                 self._runner.run_job("delete_staged_chunks", sql, job_config=job_config)
@@ -293,13 +307,14 @@ class ChunkPromoter:
 
     def _mark_chunks_promoted(self) -> None:
         """Mark the replica chunks as promoted in the database."""
-        promoted = [c.with_new_status(ChunkStatus.PROMOTED) for c in self.promotable_chunks]
+        promoted = [chunk.with_new_status(ChunkStatus.PROMOTED) for chunk in self.promotable_chunks]
         self._ppdb.update_chunks(promoted, fields={"status"})
 
     def _cleanup(self) -> None:
         """Cleanup state after executing the promotion."""
-        # Delete the temp tables.
-        for tmp_ref in self._table_refs.promoted_tmp:
+        # Delete the tmp tables.
+        for table_name in self._DEFAULT_TABLE_NAMES:
+            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, table_name + _PROMOTED_TMP_SUFFIX)
             self._bq_client.delete_table(tmp_ref, not_found_ok=True)
             logging.debug("Dropped %s (if it existed)", tmp_ref)
 

--- a/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_uploader.py
@@ -303,7 +303,7 @@ class ChunkUploader:
 
     def _post_to_stage_chunk_topic(self, gcs_uri: str, chunk_id: int) -> None:
         message = {
-            "dataset": self.config.fq_dataset_id,
+            "dataset": self.config.datasets.staging,
             "chunk_id": str(chunk_id),
             "folder": f"gs://{gcs_uri}",
         }

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -168,7 +168,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         cls,
         db_url: str,
         project_id: str,
-        dataset_id: str,
         bucket_name: str,
         object_prefix: str,
         replication_dir: str,
@@ -191,8 +190,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             Database URL in SQLAlchemy format for PPDB instance.
         project_id
             GCP project ID.
-        dataset_id
-            BigQuery dataset name without the project ID.
         bucket_name
             GCS bucket name to use for Parquet output.
         object_prefix
@@ -236,7 +233,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             sql=sql_config,
             replication_dir=replication_dir,
             bucket_name=bucket_name,
-            dataset_id=dataset_id,
             project_id=project_id,
             object_prefix=object_prefix,
             delete_existing_dirs=delete_existing_dirs,

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -51,7 +51,7 @@ from .._arrow import write_parquet
 from ..ppdb import Ppdb, PpdbReplicaChunk
 from ..sql import PasswordProvider, PpdbSqlBase, PpdbSqlBaseConfig
 from .manifest import Manifest, ParquetFileEntry
-from .ppdb_bigquery_config import PpdbBigQueryConfig
+from .ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
 from .ppdb_replica_chunk_extended import ChunkStatus, PpdbReplicaChunkExtended
 from .updates.update_records import UpdateRecords
 
@@ -316,7 +316,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             raise ConfigValidationError("Failed to validate GCS bucket") from e
 
         # Check existence of the BigQuery dataset.
-        for dataset_name in (config.datasets.internal, config.datasets.public, config.datasets.staging):
+        for dataset_type in tuple(DatasetType):
+            dataset_name = config.datasets.name_for(dataset_type)
             try:
                 check_dataset_exists(config.project_id, dataset_name)
             except Exception as e:

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -612,7 +612,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         with self._engine.begin() as connection:
             connection.execute(table.insert(), [chunk.to_row() for chunk in chunks])
 
-    def update_chunks(self, chunks: Sequence[PpdbReplicaChunkExtended], fields: set[str]) -> None:
+    def update_chunks(self, chunks: Sequence[PpdbReplicaChunkExtended], fields: set[str]) -> int:
         """Update one or more existing replica chunks in the
         ``PpdbReplicaChunk`` table.
 
@@ -641,6 +641,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         if invalid:
             raise ValueError(f"Invalid fields for update: {invalid}. Allowed: {self._UPDATABLE_FIELDS}")
         table = self.chunk_table
+        updated_count = 0
         with self._engine.begin() as connection:
             for chunk in chunks:
                 row = chunk.to_row()
@@ -651,6 +652,8 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                 )
                 if result.rowcount == 0:
                     raise LookupError(f"Cannot update chunk {chunk.id}: row does not exist")
+                updated_count += result.rowcount
+        return updated_count
 
     # ----------------------------------------------------------------------
     # Private helpers

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -316,10 +316,11 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             raise ConfigValidationError("Failed to validate GCS bucket") from e
 
         # Check existence of the BigQuery dataset.
-        try:
-            check_dataset_exists(config.project_id, config.dataset_id)
-        except Exception as e:
-            raise ConfigValidationError("Failed to validate BigQuery dataset") from e
+        for dataset_name in (config.datasets.internal, config.datasets.public, config.datasets.staging):
+            try:
+                check_dataset_exists(config.project_id, dataset_name)
+            except Exception as e:
+                raise ConfigValidationError(f"Failed to validate BigQuery dataset: {dataset_name}") from e
 
     # ----------------------------------------------------------------------
     # SQL schema and versioning class methods

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -570,6 +570,22 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                 break
         return promotable
 
+    def find_chunk_by_id(self, chunk_id: int) -> PpdbReplicaChunkExtended | None:
+        """Find a replica chunk by its ID.
+
+        Parameters
+        ----------
+        chunk_id
+            The ID of the replica chunk to find.
+
+        Returns
+        -------
+        `PpdbReplicaChunkExtended` or `None`
+            The matching replica chunk, or `None` if not found.
+        """
+        chunks = self.query_chunks(self.chunk_table.columns["apdb_replica_chunk"] == chunk_id)
+        return chunks[0] if chunks else None
+
     # ----------------------------------------------------------------------
     # Public API -- chunk mutations
     # ----------------------------------------------------------------------

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -21,13 +21,14 @@
 
 from __future__ import annotations
 
-__all__ = ["ConfigValidationError", "PpdbBigQuery"]
+__all__ = ["ConfigValidationError", "PpdbBigQuery", "UpdatableField"]
 
 import datetime
 import logging
 import os
 import shutil
 from collections.abc import Collection, Iterable, Sequence
+from enum import StrEnum
 from pathlib import Path
 
 import astropy.time
@@ -66,6 +67,13 @@ VERSION = VersionTuple(0, 1, 0)
 """
 
 
+class UpdatableField(StrEnum):
+    """Chunk fields that are allowed to be updated on existing chunks."""
+
+    STATUS = "status"
+    GCS_URI = "gcs_uri"
+
+
 class _SecretManagerPasswordProvider(PasswordProvider):
     """Retrieves a database password from Google Cloud Secret Manager.
 
@@ -102,9 +110,6 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
     config
         Configuration object with BigQuery and SQL database parameters.
     """
-
-    _UPDATABLE_FIELDS = {"status", "gcs_uri"}
-    """Fields that are allowed to be updated on existing chunks."""
 
     # ----------------------------------------------------------------------
     # Construction and properties
@@ -637,9 +642,11 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
             raise ValueError("chunks must not be empty")
         if not fields:
             raise ValueError("fields must not be empty")
-        invalid = fields - self._UPDATABLE_FIELDS
+        invalid = {field for field in fields if field not in UpdatableField}
         if invalid:
-            raise ValueError(f"Invalid fields for update: {invalid}. Allowed: {self._UPDATABLE_FIELDS}")
+            raise ValueError(
+                f"Invalid fields for update: {invalid}. Allowed: {sorted(f.value for f in UpdatableField)}"
+            )
         table = self.chunk_table
         updated_count = 0
         with self._engine.begin() as connection:
@@ -651,7 +658,7 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                     .values(**{k: v for k, v in row.items() if k in fields})
                 )
                 if result.rowcount == 0:
-                    raise LookupError(f"Cannot update chunk {chunk.id}: row does not exist")
+                    raise LookupError(f"Chunk {chunk.id} does not exist")
                 updated_count += result.rowcount
         return updated_count
 

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -86,9 +86,6 @@ class PpdbBigQueryConfig(PpdbConfig):
     project_id: str
     """Google Cloud project ID."""
 
-    dataset_id: str  # TODO: This should be removed by DM-54681.
-    """Target BigQuery dataset ID, without the project."""
-
     bucket_name: str
     """Name of Google Cloud Storage bucket for uploading chunks."""
 
@@ -141,12 +138,6 @@ class PpdbBigQueryConfig(PpdbConfig):
             the replication path and the chunk ID.
         """
         return self.replication_path / str(chunk_id)
-
-    # TODO: This function should be removed by DM-54681.
-    @property
-    def fq_dataset_id(self) -> str:
-        """Fully qualified BigQuery dataset ID, including project (`str`)."""
-        return f"{self.project_id}:{self.dataset_id}"
 
     def fqn_for(self, dataset_type: DatasetType, table_name: str | None = None) -> str:
         """Return the fully qualified BigQuery dataset name for a dataset type.

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -148,13 +148,15 @@ class PpdbBigQueryConfig(PpdbConfig):
         """Fully qualified BigQuery dataset ID, including project (`str`)."""
         return f"{self.project_id}:{self.dataset_id}"
 
-    def fqn_for(self, dataset_type: DatasetType) -> str:
+    def fqn_for(self, dataset_type: DatasetType, table_name: str | None = None) -> str:
         """Return the fully qualified BigQuery dataset name for a dataset type.
 
         Parameters
         ----------
         dataset_type
             Type of dataset to get the name for.
+        table_name
+            Optional table name to include in the fully qualified name.
 
         Returns
         -------
@@ -162,4 +164,7 @@ class PpdbBigQueryConfig(PpdbConfig):
             Fully qualified BigQuery dataset name (project.dataset).
         """
         dataset_name = self.datasets.name_for(dataset_type)
-        return f"{self.project_id}.{dataset_name}"
+        fqn = f"{self.project_id}.{dataset_name}"
+        if table_name:
+            fqn = f"{fqn}.{table_name}"
+        return fqn

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -140,7 +140,8 @@ class PpdbBigQueryConfig(PpdbConfig):
         return self.replication_path / str(chunk_id)
 
     def fqn_for(self, dataset_type: DatasetType, table_name: str | None = None) -> str:
-        """Return the fully qualified BigQuery dataset name for a dataset type.
+        """Return the fully qualified BigQuery dataset or table name (if
+        provided) for a dataset type.
 
         Parameters
         ----------
@@ -152,7 +153,7 @@ class PpdbBigQueryConfig(PpdbConfig):
         Returns
         -------
         str
-            Fully qualified BigQuery dataset name (project.dataset).
+            Fully qualified BigQuery dataset or table name.
         """
         dataset_name = self.datasets.name_for(dataset_type)
         fqn = f"{self.project_id}.{dataset_name}"

--- a/python/lsst/dax/ppdb/bigquery/table_refs.py
+++ b/python/lsst/dax/ppdb/bigquery/table_refs.py
@@ -23,51 +23,62 @@ from __future__ import annotations
 
 __all__ = ["TableRefs"]
 
-from pydantic import BaseModel
+from .ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
 
 
-class TableRefs(BaseModel, frozen=True):
-    """Fully-qualified BigQuery table references for a set of tables.
-
-    Provides named properties for production, staging, and promoted temporary
-    table FQNs derived from the base ``table_names``.  The format strings
-    used for staging and promoted-tmp names are configurable.
+class TableRefs:
+    """Builder for fully qualified BigQuery table references.
 
     Parameters
     ----------
-    project_id
-        GCP project ID.
-    dataset_id
-        BigQuery dataset ID.
-    table_names
-        Base table names.
-    staging_format
-        Format string for staging table names.
-    promoted_tmp_format
-        Format string for promoted temporary table names.
+    config
+        Configuration providing the project ID and dataset names.
     """
 
-    project_id: str
-    dataset_id: str
-    table_names: tuple[str, ...]
-    staging_format: str = "_{}_staging"
-    promoted_tmp_format: str = "_{}_promoted_tmp"
+    def __init__(self, config: PpdbBigQueryConfig):
+        self._config = config
 
-    def _fqns(self, fmt: str = "{}") -> list[str]:
-        """Build fully-qualified names using the given format string."""
-        return [f"{self.project_id}.{self.dataset_id}.{fmt.format(name)}" for name in self.table_names]
+    def staging(self, table_name: str) -> str:
+        """Return the fully qualified staging table reference.
 
-    @property
-    def prod(self) -> list[str]:
-        """Fully-qualified production table names (`list` [`str`])."""
-        return self._fqns()
+        Parameters
+        ----------
+        table_name
+            Name of the table.
 
-    @property
-    def staging(self) -> list[str]:
-        """Fully-qualified staging table names (`list` [`str`])."""
-        return self._fqns(self.staging_format)
+        Returns
+        -------
+        `str`
+            Fully qualified staging table reference.
+        """
+        return self._config.fqn_for(DatasetType.STAGING, table_name)
 
-    @property
-    def promoted_tmp(self) -> list[str]:
-        """Fully-qualified promoted temporary table names (`list` [`str`])."""
-        return self._fqns(self.promoted_tmp_format)
+    def internal(self, table_name: str) -> str:
+        """Return the fully qualified internal table reference.
+
+        Parameters
+        ----------
+        table_name
+            Name of the table.
+
+        Returns
+        -------
+        `str`
+            Fully qualified internal table reference.
+        """
+        return self._config.fqn_for(DatasetType.INTERNAL, table_name)
+
+    def public(self, table_name: str) -> str:
+        """Return the fully qualified public table reference.
+
+        Parameters
+        ----------
+        table_name
+            Name of the table.
+
+        Returns
+        -------
+        `str`
+            Fully qualified public table reference.
+        """
+        return self._config.fqn_for(DatasetType.PUBLIC, table_name)

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -30,7 +30,7 @@ from collections.abc import Sequence
 
 from google.cloud import bigquery, storage
 
-from ..ppdb_bigquery_config import PpdbBigQueryConfig
+from ..ppdb_bigquery_config import DatasetType, PpdbBigQueryConfig
 from ..ppdb_replica_chunk_extended import PpdbReplicaChunkExtended
 from .update_record_expander import UpdateRecordExpander
 from .update_records import UpdateRecords
@@ -76,7 +76,6 @@ class UpdatesManager:
     ) -> None:
         # Get some necessary setup information from the config.
         project_id = config.project_id
-        dataset_id = config.dataset_id
         bucket_name = config.bucket_name
 
         # Merger instances for handling each target table.
@@ -87,7 +86,7 @@ class UpdatesManager:
         self._updates_table = UpdatesTable(
             self._bq_client,
             project_id,
-            dataset_id,
+            config.datasets.staging,
         )
 
         # Setup the GCS client and bucket.
@@ -95,7 +94,7 @@ class UpdatesManager:
         self._bucket = self._gcs_client.bucket(bucket_name)
 
         # Set the target dataset FQN for the mergers to use.
-        self._target_dataset_fqn = f"{project_id}.{dataset_id}"
+        self._target_dataset_fqn = config.fqn_for(DatasetType.INTERNAL)
 
     def apply_updates(self, replica_chunks: Sequence[PpdbReplicaChunkExtended]) -> None:
         """Apply update records from replica chunk data to target tables in

--- a/python/lsst/dax/ppdb/cli/options.py
+++ b/python/lsst/dax/ppdb/cli/options.py
@@ -217,13 +217,6 @@ def bigquery_options(parser: argparse.ArgumentParser) -> None:
         required=True,
     )
     group.add_argument(
-        "--dataset-id",
-        type=str,
-        help="BigQuery dataset ID, e.g., 'my_dataset'.",
-        metavar="DATASET_NAME",
-        required=True,
-    )
-    group.add_argument(
         "--project-id",
         type=str,
         help="Google Cloud project ID containing the dataset.",

--- a/python/lsst/dax/ppdb/scripts/create_bigquery.py
+++ b/python/lsst/dax/ppdb/scripts/create_bigquery.py
@@ -36,7 +36,6 @@ def create_bigquery(
     output_config: str,
     db_url: str,
     project_id: str,
-    dataset_id: str,
     bucket_name: str,
     object_prefix: str,
     replication_dir: str,
@@ -61,8 +60,6 @@ def create_bigquery(
         Database URL in SQLAlchemy format for PPDB instance.
     project_id
         GCP project ID.
-    dataset_id
-        BigQuery dataset name, e.g., 'my_project:my_dataset'.
     bucket_name
         GCS bucket name to use for Parquet output.
     object_prefix
@@ -103,7 +100,6 @@ def create_bigquery(
         bucket_name=bucket_name,
         object_prefix=object_prefix,
         project_id=project_id,
-        dataset_id=dataset_id,
         validate_config=validate_config,
     )
     _LOG.info("Created BigQuery configuration: %s", bq_config)

--- a/python/lsst/dax/ppdb/tests/__init__.py
+++ b/python/lsst/dax/ppdb/tests/__init__.py
@@ -19,4 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from ._bigquery import *
 from ._ppdb import *
+from ._updates import *

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -69,9 +69,6 @@ __all__ = [
 _LOG = logging.getLogger(__name__)
 
 
-_APDB_SCHEMA_RESOURCE_PATH = "resource://lsst.dax.ppdb/resources/config/schemas/test_apdb_schema.yaml"
-
-
 def make_bigquery_config(
     test_name: str = "test",
     db_url: str = "sqlite:///:memory:",
@@ -127,7 +124,7 @@ def make_bigquery_config(
         sql=PpdbSqlBaseConfig(
             db_url=db_url,
             schema_name=schema_name,
-            felis_path=_APDB_SCHEMA_RESOURCE_PATH,
+            felis_path=TEST_SCHEMA_RESOURCE_PATH,
         ),
     )
     return config
@@ -282,7 +279,7 @@ class SqliteMixin:
     def make_apdb_instance(self) -> ApdbConfig:
         """Make APDB instance for tests."""
         return ApdbSql.init_database(
-            schema_file=_APDB_SCHEMA_RESOURCE_PATH,
+            schema_file=TEST_SCHEMA_RESOURCE_PATH,
             ss_schema_file="",
             db_url=self.apdb_url,
             enable_replica=True,

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -20,6 +20,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+__all__ = [
+    "PostgresMixin",
+    "SqliteMixin",
+    "create_bucket",
+    "create_datasets",
+    "delete_bucket",
+    "drop_datasets",
+    "have_valid_google_credentials",
+    "init_bigquery_sql",
+    "json_rows_to_buf",
+    "make_bigquery_config",
+    "search_indexes_enabled",
+]
+
 import gc
 import io
 import json
@@ -35,14 +49,11 @@ import google.auth
 from google.api_core.exceptions import GoogleAPIError
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from google.auth.transport.requests import Request
-from google.cloud import (
-    bigquery,
-    storage,
-)
+from google.cloud import bigquery, storage
 
-from lsst.dax.apdb import (
-    ApdbConfig,
-)
+
+from lsst.dax.apdb import ApdbConfig
+
 from lsst.dax.apdb.sql import ApdbSql
 from lsst.dax.ppdb.bigquery import Datasets, DatasetType, PpdbBigQuery, PpdbBigQueryConfig
 from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
@@ -52,20 +63,6 @@ try:
     import testing.postgresql
 except ImportError:
     testing = None
-
-__all__ = [
-    "PostgresMixin",
-    "SqliteMixin",
-    "create_bucket",
-    "create_datasets",
-    "delete_bucket",
-    "drop_datasets",
-    "have_valid_google_credentials",
-    "init_bigquery_sql",
-    "json_rows_to_buf",
-    "make_bigquery_config",
-    "search_indexes_enabled",
-]
 
 _LOG = logging.getLogger(__name__)
 
@@ -191,8 +188,12 @@ def drop_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetTyp
     if dataset_types is None:
         dataset_types = tuple(DatasetType)
     bq_client = bigquery.Client(project=config.project_id)
+    failures: list[GoogleAPIError] = []
+
     for dataset_type in dataset_types:
         dataset_fqn = config.fqn_for(dataset_type)
+        _LOG.debug("Dropping BigQuery dataset %s", dataset_fqn)
+
         try:
             bq_client.delete_dataset(
                 dataset_fqn,
@@ -200,8 +201,11 @@ def drop_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetTyp
                 not_found_ok=True,
             )
         except GoogleAPIError as e:
-            _LOG.exception("Failed to delete dataset %s: %s", dataset_fqn, e)
-            raise
+            _LOG.error("Failed to drop BigQuery dataset %s", dataset_fqn)
+            failures.append(e)
+
+    if failures:
+        raise ExceptionGroup("Failed to drop BigQuery datasets", failures)
 
 
 def create_bucket(config: PpdbBigQueryConfig) -> storage.Bucket:

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -59,7 +59,6 @@ __all__ = [
     "create_datasets",
     "delete_datasets",
     "delete_test_bucket",
-    "generate_test_bucket_name",
     "have_valid_google_credentials",
     "init_bigquery_sql",
     "json_rows_to_buf",
@@ -208,12 +207,6 @@ def json_rows_to_buf(rows: list[dict]) -> io.StringIO:
         buf.write(json.dumps(row) + "\n")
     buf.seek(0)
     return buf
-
-
-def generate_test_bucket_name(test_prefix: str = "ppdb-test") -> str:
-    """Generate a unique bucket name for testing."""
-    test_id = uuid.uuid4().hex[:16]
-    return f"{test_prefix}-{test_id}"
 
 
 def delete_test_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> None:

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -57,8 +57,8 @@ __all__ = [
     "SqliteMixin",
     "create_bucket",
     "create_datasets",
-    "delete_datasets",
-    "delete_test_bucket",
+    "delete_bucket",
+    "drop_datasets",
     "have_valid_google_credentials",
     "init_bigquery_sql",
     "json_rows_to_buf",
@@ -159,7 +159,7 @@ def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType]
             raise
 
 
-def delete_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
+def drop_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
     """Delete the BigQuery datasets for testing.
 
     Parameters
@@ -209,7 +209,7 @@ def json_rows_to_buf(rows: list[dict]) -> io.StringIO:
     return buf
 
 
-def delete_test_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> None:
+def delete_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> None:
     """Delete a cloud storage bucket that was created for testing.
 
     Parameters

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -28,10 +28,11 @@ import os
 import shutil
 import tempfile
 import uuid
-from typing import Any
+from typing import Any, cast
 
 import google.auth
-from google.auth.exceptions import DefaultCredentialsError
+from google.auth.credentials import Credentials
+from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from google.auth.transport.requests import Request
 from google.cloud import (
     bigquery,
@@ -42,8 +43,7 @@ from lsst.dax.apdb import (
     ApdbConfig,
 )
 from lsst.dax.apdb.sql import ApdbSql
-from lsst.dax.ppdb import PpdbConfig
-from lsst.dax.ppdb.bigquery import DatasetType, PpdbBigQuery, PpdbBigQueryConfig
+from lsst.dax.ppdb.bigquery import Datasets, DatasetType, PpdbBigQuery, PpdbBigQueryConfig
 from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests._ppdb import TEST_SCHEMA_RESOURCE_PATH
 
@@ -88,10 +88,22 @@ def make_bigquery_config(
     db_url
         Optional database URL to use for the test. If not provided, a default
         SQLite in-memory config will be used.
+    schema_name
+        Optional schema name to use for the test. If not provided, a default
+        schema name will be used.
+    replication_dir
+        Optional directory to use for storing replica chunk data. If not
+        provided, a temporary directory will be created.
+    delete_existing_dirs
+        If True, existing directories for chunks will be deleted before export.
+        If False, an error will be raised if the directory already exists.
     """
     unique_id = uuid.uuid4().hex[:16]
 
     credentials, project_id = google.auth.default()
+
+    if project_id is None:
+        raise RuntimeError("Google Cloud project ID could not be determined from credentials")
 
     if replication_dir is None:
         replication_dir = tempfile.mkdtemp()
@@ -102,11 +114,11 @@ def make_bigquery_config(
         object_prefix="data/test",
         replication_dir=replication_dir,
         delete_existing_dirs=delete_existing_dirs,
-        datasets={
-            "staging": f"{test_name}_staging_{unique_id}",
-            "internal": f"{test_name}_internal_{unique_id}",
-            "public": f"{test_name}_public_{unique_id}",
-        },
+        datasets=Datasets(
+            staging=f"{test_name}_staging_{unique_id}",
+            internal=f"{test_name}_internal_{unique_id}",
+            public=f"{test_name}_public_{unique_id}",
+        ),
         sql=PpdbSqlBaseConfig(
             db_url=db_url,
             schema_name=schema_name,
@@ -137,7 +149,8 @@ def init_bigquery_sql(config: PpdbBigQueryConfig, db_drop: bool = True) -> None:
 def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
     """Create the BigQuery datasets for testing.
 
-    This will not create any tables, just the empty datasets.
+    This will not create any tables, just the empty datasets. The tests will
+    generally create their own tables in these datasets as needed.
 
     Parameters
     ----------
@@ -160,7 +173,7 @@ def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType]
 
 
 def drop_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
-    """Delete the BigQuery datasets for testing.
+    """Drop the BigQuery datasets.
 
     Parameters
     ----------
@@ -182,8 +195,8 @@ def drop_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] |
             raise
 
 
-def create_bucket(config: PpdbBigQueryConfig) -> None:
-    """Create the cloud storage bucket for testing.
+def create_bucket(config: PpdbBigQueryConfig) -> storage.Bucket:
+    """Create the cloud storage bucket from the config.
 
     Parameters
     ----------
@@ -196,6 +209,7 @@ def create_bucket(config: PpdbBigQueryConfig) -> None:
     except Exception as e:
         _LOG.exception("Failed to create bucket %s: %s", config.bucket_name, e)
         raise
+    return storage_client.get_bucket(config.bucket_name)
 
 
 def json_rows_to_buf(rows: list[dict]) -> io.StringIO:
@@ -210,7 +224,7 @@ def json_rows_to_buf(rows: list[dict]) -> io.StringIO:
 
 
 def delete_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> None:
-    """Delete a cloud storage bucket that was created for testing.
+    """Delete a cloud storage bucket.
 
     Parameters
     ----------
@@ -236,7 +250,7 @@ def delete_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> N
 
 
 class SqliteMixin:
-    """Mixin class to provide Sqlite-specific setup/teardown and instance
+    """Mixin class to provide Sqlite-specific setup, teardown, and instance
     creation.
     """
 
@@ -248,7 +262,7 @@ class SqliteMixin:
     def tearDown(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
-    def make_instance(self, test_name: str = "test") -> PpdbConfig:
+    def make_instance(self, test_name: str = "test") -> PpdbBigQueryConfig:
         """Make config class instance used in all tests."""
         config = make_bigquery_config(db_url=self.ppdb_url, replication_dir=self.tempdir, test_name=test_name)
         init_bigquery_sql(config)
@@ -265,7 +279,7 @@ class SqliteMixin:
 
 
 class PostgresMixin:
-    """Mixin class to provide Postgres-specific setup/teardown and instance
+    """Mixin class to provide Postgres-specific setup, teardown, and instance
     creation.
     """
 
@@ -274,7 +288,10 @@ class PostgresMixin:
     @classmethod
     def setUpClass(cls) -> None:
         # Create the postgres test server.
-        cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
+        if testing is not None:
+            cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
+        else:
+            raise RuntimeError("testing.postgresql module is not available")
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -291,7 +308,7 @@ class PostgresMixin:
         self.server = self.postgresql()
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
-    def make_instance(self, test_name: str = "test") -> PpdbConfig:
+    def make_instance(self, test_name: str = "test") -> PpdbBigQueryConfig:
         """Make config class instance used in all tests."""
         config = make_bigquery_config(
             test_name=test_name,
@@ -328,13 +345,11 @@ def have_valid_google_credentials() -> bool:
         Raised for other transport or configuration failures.
     """
     try:
-        credentials, _ = google.auth.default()
-    except DefaultCredentialsError:
+        raw_credentials, _ = google.auth.default()
+        credentials = cast(Credentials, raw_credentials)
+        credentials.refresh(Request())
+    except (DefaultCredentialsError, RefreshError):
         return False
-
-    # This will validate the default credentials that were found in the
-    # environment.
-    credentials.refresh(Request())
 
     return True
 

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -46,23 +46,17 @@ from collections.abc import Sequence
 from typing import Any
 
 import google.auth
+import testing.postgresql
 from google.api_core.exceptions import GoogleAPIError
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from google.auth.transport.requests import Request
 from google.cloud import bigquery, storage
 
-
 from lsst.dax.apdb import ApdbConfig
-
 from lsst.dax.apdb.sql import ApdbSql
 from lsst.dax.ppdb.bigquery import Datasets, DatasetType, PpdbBigQuery, PpdbBigQueryConfig
 from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests._ppdb import TEST_SCHEMA_RESOURCE_PATH
-
-try:
-    import testing.postgresql
-except ImportError:
-    testing = None
 
 _LOG = logging.getLogger(__name__)
 
@@ -301,10 +295,7 @@ class PostgresMixin:
     @classmethod
     def setUpClass(cls) -> None:
         # Create the postgres test server.
-        if testing is not None:
-            cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
-        else:
-            raise RuntimeError("testing.postgresql module is not available")
+        cls.postgresql = testing.postgresql.PostgresqlFactory(cache_initialized_db=True)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -28,10 +28,9 @@ import os
 import shutil
 import tempfile
 import uuid
-from typing import Any, cast
+from typing import Any
 
 import google.auth
-from google.auth.credentials import Credentials
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from google.auth.transport.requests import Request
 from google.cloud import (
@@ -104,7 +103,7 @@ def make_bigquery_config(
     # use a placeholder if not available.
     project_id: str | None = None
     try:
-        _credentials, project_id = google.auth.default()
+        _, project_id = google.auth.default()
     except DefaultCredentialsError:
         pass
     if project_id is None:
@@ -350,8 +349,7 @@ def have_valid_google_credentials() -> bool:
         Raised for other transport or configuration failures.
     """
     try:
-        raw_credentials, _ = google.auth.default()
-        credentials = cast(Credentials, raw_credentials)
+        credentials, _ = google.auth.default()
         credentials.refresh(Request())
     except (DefaultCredentialsError, RefreshError):
         return False

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -28,6 +28,7 @@ import os
 import shutil
 import tempfile
 import uuid
+from collections.abc import Sequence
 from typing import Any
 
 import google.auth
@@ -150,7 +151,7 @@ def init_bigquery_sql(config: PpdbBigQueryConfig, db_drop: bool = True) -> None:
     PpdbBigQuery.make_database(engine, config.sql, sa_metadata, schema_version, db_drop)
 
 
-def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
+def create_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetType] | None = None) -> None:
     """Create the BigQuery datasets for testing.
 
     This will not create any tables, just the empty datasets. The tests will
@@ -165,18 +166,20 @@ def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType]
         created.
     """
     if dataset_types is None:
-        dataset_types = [DatasetType.STAGING, DatasetType.INTERNAL, DatasetType.PUBLIC]
+        dataset_types = tuple(DatasetType)
     bq_client = bigquery.Client(project=config.project_id)
     for dataset_type in dataset_types:
         dataset_fqn = config.fqn_for(dataset_type)
         try:
-            bq_client.create_dataset(bigquery.Dataset(dataset_fqn))
+            dataset = bigquery.Dataset(dataset_fqn)
+            dataset.default_table_expiration_ms = 60 * 60 * 1000  # 1 hour in milliseconds
+            bq_client.create_dataset(dataset)
         except Exception as e:
             _LOG.exception("Failed to create dataset %s: %s", dataset_fqn, e)
             raise
 
 
-def drop_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
+def drop_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetType] | None = None) -> None:
     """Drop the BigQuery datasets.
 
     Parameters
@@ -188,12 +191,16 @@ def drop_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] |
         deleted.
     """
     if dataset_types is None:
-        dataset_types = [DatasetType.STAGING, DatasetType.INTERNAL, DatasetType.PUBLIC]
+        dataset_types = tuple(DatasetType)
     bq_client = bigquery.Client(project=config.project_id)
     for dataset_type in dataset_types:
         dataset_fqn = config.fqn_for(dataset_type)
         try:
-            bq_client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
+            bq_client.delete_dataset(
+                dataset_fqn,
+                delete_contents=True,
+                not_found_ok=True,
+            )
         except Exception as e:
             _LOG.exception("Failed to delete dataset %s: %s", dataset_fqn, e)
             raise

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -33,14 +33,18 @@ from typing import Any
 import google.auth
 from google.auth.exceptions import DefaultCredentialsError
 from google.auth.transport.requests import Request
-from google.cloud import storage
+from google.cloud import (
+    bigquery,
+    storage,
+)
 
 from lsst.dax.apdb import (
     ApdbConfig,
 )
 from lsst.dax.apdb.sql import ApdbSql
 from lsst.dax.ppdb import PpdbConfig
-from lsst.dax.ppdb.bigquery import PpdbBigQuery
+from lsst.dax.ppdb.bigquery import DatasetType, PpdbBigQuery, PpdbBigQueryConfig
+from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests._ppdb import TEST_SCHEMA_RESOURCE_PATH
 
 try:
@@ -52,10 +56,15 @@ __all__ = [
     "TEST_CONFIG",
     "PostgresMixin",
     "SqliteMixin",
+    "create_bucket",
+    "create_datasets",
+    "delete_datasets",
     "delete_test_bucket",
     "generate_test_bucket_name",
     "have_valid_google_credentials",
+    "init_bigquery_sql",
     "json_rows_to_buf",
+    "make_bigquery_config",
     "search_indexes_enabled",
 ]
 
@@ -71,6 +80,135 @@ TEST_CONFIG = {
     "dataset_id": "test_dataset",
     "project_id": "test_project",
 }
+
+_APDB_SCHEMA_RESOURCE_PATH = "resource://lsst.dax.ppdb/resources/config/schemas/test_apdb_schema.yaml"
+
+
+def make_bigquery_config(
+    test_name: str = "test",
+    db_url: str = "sqlite:///:memory:",
+    schema_name: str | None = None,
+    replication_dir: str | None = None,
+    delete_existing_dirs: bool = True,
+) -> PpdbBigQueryConfig:
+    """Make a complete PPDB BigQuery configuration for testing.
+
+    Parameters
+    ----------
+    test_name
+        The name of the test, used to create unique bucket and dataset names.
+    db_url
+        Optional database URL to use for the test. If not provided, a default
+        SQLite in-memory config will be used.
+    """
+    unique_id = uuid.uuid4().hex[:16]
+
+    credentials, project_id = google.auth.default()
+
+    if replication_dir is None:
+        replication_dir = tempfile.mkdtemp()
+
+    config = PpdbBigQueryConfig(
+        dataset_id="fake",  # FIXME: Remove this eventually.
+        project_id=project_id,
+        bucket_name=f"{test_name.lower().replace('_', '-')}-bucket-{unique_id}",
+        object_prefix="data/test",
+        replication_dir=replication_dir,
+        delete_existing_dirs=delete_existing_dirs,
+        datasets={
+            "staging": f"{test_name}_staging_{unique_id}",
+            "internal": f"{test_name}_internal_{unique_id}",
+            "public": f"{test_name}_public_{unique_id}",
+        },
+        sql=PpdbSqlBaseConfig(
+            db_url=db_url,
+            schema_name=schema_name,
+            felis_path=_APDB_SCHEMA_RESOURCE_PATH,
+        ),
+    )
+    return config
+
+
+def init_bigquery_sql(config: PpdbBigQueryConfig, db_drop: bool = True) -> None:
+    """Initialize the SQL database for the PPDB BigQuery test instance.
+
+    Parameters
+    ----------
+    config
+        Configuration object with BigQuery and SQL database parameters.
+    db_drop
+        If True then drop existing db tables.
+    """
+    sa_metadata, schema_version = PpdbBigQuery.read_schema(
+        config.sql.felis_path, config.sql.schema_name, config.sql.felis_schema, config.sql.db_url
+    )
+    password_provider = PpdbBigQuery._make_password_provider(config.project_id)
+    engine = PpdbBigQuery.make_engine(config.sql, password_provider=password_provider)
+    PpdbBigQuery.make_database(engine, config.sql, sa_metadata, schema_version, db_drop)
+
+
+def create_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
+    """Create the BigQuery datasets for testing.
+
+    This will not create any tables, just the empty datasets.
+
+    Parameters
+    ----------
+    config
+        Configuration object with BigQuery and SQL database parameters.
+    dataset_types
+        List of dataset types to create. If None, all dataset types will be
+        created.
+    """
+    if dataset_types is None:
+        dataset_types = [DatasetType.STAGING, DatasetType.INTERNAL, DatasetType.PUBLIC]
+    bq_client = bigquery.Client(project=config.project_id)
+    for dataset_type in dataset_types:
+        dataset_fqn = config.fqn_for(dataset_type)
+        try:
+            bq_client.create_dataset(bigquery.Dataset(dataset_fqn))
+        except Exception as e:
+            _LOG.exception("Failed to create dataset %s: %s", dataset_fqn, e)
+            raise
+
+
+def delete_datasets(config: PpdbBigQueryConfig, dataset_types: list[DatasetType] | None = None) -> None:
+    """Delete the BigQuery datasets for testing.
+
+    Parameters
+    ----------
+    config
+        Configuration object with BigQuery and SQL database parameters.
+    dataset_types
+        List of dataset types to delete. If None, all dataset types will be
+        deleted.
+    """
+    if dataset_types is None:
+        dataset_types = [DatasetType.STAGING, DatasetType.INTERNAL, DatasetType.PUBLIC]
+    bq_client = bigquery.Client(project=config.project_id)
+    for dataset_type in dataset_types:
+        dataset_fqn = config.fqn_for(dataset_type)
+        try:
+            bq_client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
+        except Exception as e:
+            _LOG.exception("Failed to delete dataset %s: %s", dataset_fqn, e)
+            raise
+
+
+def create_bucket(config: PpdbBigQueryConfig) -> None:
+    """Create the cloud storage bucket for testing.
+
+    Parameters
+    ----------
+    config
+        Configuration object with BigQuery and SQL database parameters.
+    """
+    storage_client = storage.Client(project=config.project_id)
+    try:
+        storage_client.create_bucket(config.bucket_name)
+    except Exception as e:
+        _LOG.exception("Failed to create bucket %s: %s", config.bucket_name, e)
+        raise
 
 
 def json_rows_to_buf(rows: list[dict]) -> io.StringIO:
@@ -90,26 +228,30 @@ def generate_test_bucket_name(test_prefix: str = "ppdb-test") -> str:
     return f"{test_prefix}-{test_id}"
 
 
-def delete_test_bucket(bucket_or_bucket_name: str | storage.Bucket) -> None:
+def delete_test_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> None:
     """Delete a cloud storage bucket that was created for testing.
 
     Parameters
     ----------
-    bucket_or_bucket_name
-        The name of the bucket or the actual bucket to delete.
+    bucket_target
+        The name of the bucket, the actual bucket, or a PpdbBigQueryConfig
+        instance with the name to delete.
     """
     storage_client = storage.Client()
     try:
-        if isinstance(bucket_or_bucket_name, str):
-            bucket = storage_client.bucket(bucket_or_bucket_name)
+        if isinstance(bucket_target, str):
+            bucket = storage_client.bucket(bucket_target)
+        elif isinstance(bucket_target, PpdbBigQueryConfig):
+            bucket = storage_client.bucket(bucket_target.bucket_name)
         else:
-            bucket = bucket_or_bucket_name
+            bucket = bucket_target
         blobs = list(bucket.list_blobs())
         for blob in blobs:
             blob.delete()
         bucket.delete()
     except Exception as e:
         _LOG.exception("Failed to delete test GCS bucket: %s", e)
+        raise
 
 
 class SqliteMixin:
@@ -125,27 +267,20 @@ class SqliteMixin:
     def tearDown(self) -> None:
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
-    def make_instance(self, **kwargs: Any) -> PpdbConfig:
+    def make_instance(self, test_name: str = "test") -> PpdbConfig:
         """Make config class instance used in all tests."""
-        kw = {
-            **TEST_CONFIG,
-            "db_url": self.ppdb_url,
-            "felis_path": TEST_SCHEMA_RESOURCE_PATH,
-            "replication_dir": self.tempdir,
-        }
-        bq_config = PpdbBigQuery.init_bigquery(**kw)  # type: ignore[arg-type]
-        return bq_config
+        config = make_bigquery_config(db_url=self.ppdb_url, replication_dir=self.tempdir, test_name=test_name)
+        init_bigquery_sql(config)
+        return config
 
-    def make_apdb_instance(self, **kwargs: Any) -> ApdbConfig:
+    def make_apdb_instance(self) -> ApdbConfig:
         """Make APDB instance for tests."""
-        kw = {
-            "schema_file": TEST_SCHEMA_RESOURCE_PATH,
-            "ss_schema_file": "",
-            "db_url": self.apdb_url,
-            "enable_replica": True,
-        }
-        kw.update(kwargs)
-        return ApdbSql.init_database(**kw)  # type: ignore[arg-type]
+        return ApdbSql.init_database(
+            schema_file=_APDB_SCHEMA_RESOURCE_PATH,
+            ss_schema_file="",
+            db_url=self.apdb_url,
+            enable_replica=True,
+        )
 
 
 class PostgresMixin:
@@ -175,28 +310,25 @@ class PostgresMixin:
         self.server = self.postgresql()
         shutil.rmtree(self.tempdir, ignore_errors=True)
 
-    def make_instance(self, config_dict: dict[str, Any] = TEST_CONFIG, **kwargs: Any) -> PpdbConfig:
+    def make_instance(self, test_name: str = "test") -> PpdbConfig:
         """Make config class instance used in all tests."""
-        kw = {
-            **config_dict,
-            "db_url": self.server.url(),
-            "db_schema": "ppdb_test",
-            "felis_path": TEST_SCHEMA_RESOURCE_PATH,
-            "replication_dir": self.tempdir,
-        }
-        bq_config = PpdbBigQuery.init_bigquery(**kw)
-        return bq_config
+        config = make_bigquery_config(
+            test_name=test_name,
+            db_url=self.server.url(),
+            replication_dir=self.tempdir,
+            schema_name="ppdb_test",
+        )
+        init_bigquery_sql(config)
+        return config
 
-    def make_apdb_instance(self, **kwargs: Any) -> ApdbConfig:
-        kw = {
-            "schema_file": TEST_SCHEMA_RESOURCE_PATH,
-            "ss_schema_file": "",
-            "db_url": self.server.url(),
-            "namespace": "apdb",
-            "enable_replica": True,
-        }
-        kw.update(kwargs)
-        return ApdbSql.init_database(**kw)
+    def make_apdb_instance(self) -> ApdbConfig:
+        return ApdbSql.init_database(
+            schema_file=TEST_SCHEMA_RESOURCE_PATH,
+            ss_schema_file="",
+            db_url=self.server.url(),
+            namespace="apdb",
+            enable_replica=True,
+        )
 
 
 def have_valid_google_credentials() -> bool:

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -32,6 +32,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import google.auth
+from google.api_core.exceptions import GoogleAPIError
 from google.auth.exceptions import DefaultCredentialsError, RefreshError
 from google.auth.transport.requests import Request
 from google.cloud import (
@@ -171,7 +172,7 @@ def create_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetT
             dataset = bigquery.Dataset(dataset_fqn)
             dataset.default_table_expiration_ms = 60 * 60 * 1000  # 1 hour in milliseconds
             bq_client.create_dataset(dataset)
-        except Exception as e:
+        except GoogleAPIError as e:
             _LOG.exception("Failed to create dataset %s: %s", dataset_fqn, e)
             raise
 
@@ -198,7 +199,7 @@ def drop_datasets(config: PpdbBigQueryConfig, dataset_types: Sequence[DatasetTyp
                 delete_contents=True,
                 not_found_ok=True,
             )
-        except Exception as e:
+        except GoogleAPIError as e:
             _LOG.exception("Failed to delete dataset %s: %s", dataset_fqn, e)
             raise
 
@@ -214,7 +215,7 @@ def create_bucket(config: PpdbBigQueryConfig) -> storage.Bucket:
     storage_client = storage.Client(project=config.project_id)
     try:
         storage_client.create_bucket(config.bucket_name)
-    except Exception as e:
+    except GoogleAPIError as e:
         _LOG.exception("Failed to create bucket %s: %s", config.bucket_name, e)
         raise
     return storage_client.get_bucket(config.bucket_name)
@@ -252,7 +253,7 @@ def delete_bucket(bucket_target: str | storage.Bucket | PpdbBigQueryConfig) -> N
         for blob in blobs:
             blob.delete()
         bucket.delete()
-    except Exception as e:
+    except GoogleAPIError as e:
         _LOG.exception("Failed to delete test GCS bucket: %s", e)
         raise
 

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -100,10 +100,15 @@ def make_bigquery_config(
     """
     unique_id = uuid.uuid4().hex[:16]
 
-    credentials, project_id = google.auth.default()
-
+    # Determine the Google Cloud project ID from the default credentials or
+    # use a placeholder if not available.
+    project_id: str | None = None
+    try:
+        _credentials, project_id = google.auth.default()
+    except DefaultCredentialsError:
+        pass
     if project_id is None:
-        raise RuntimeError("Google Cloud project ID could not be determined from credentials")
+        project_id = "Unavailable"
 
     if replication_dir is None:
         replication_dir = tempfile.mkdtemp()

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -53,7 +53,6 @@ except ImportError:
     testing = None
 
 __all__ = [
-    "TEST_CONFIG",
     "PostgresMixin",
     "SqliteMixin",
     "create_bucket",
@@ -70,16 +69,6 @@ __all__ = [
 
 _LOG = logging.getLogger(__name__)
 
-
-TEST_CONFIG = {
-    "db_drop": True,
-    "validate_config": False,
-    "delete_existing_dirs": True,
-    "bucket_name": "ppdb-test",
-    "object_prefix": "data/test",
-    "dataset_id": "test_dataset",
-    "project_id": "test_project",
-}
 
 _APDB_SCHEMA_RESOURCE_PATH = "resource://lsst.dax.ppdb/resources/config/schemas/test_apdb_schema.yaml"
 
@@ -109,7 +98,6 @@ def make_bigquery_config(
         replication_dir = tempfile.mkdtemp()
 
     config = PpdbBigQueryConfig(
-        dataset_id="fake",  # FIXME: Remove this eventually.
         project_id=project_id,
         bucket_name=f"{test_name.lower().replace('_', '-')}-bucket-{unique_id}",
         object_prefix="data/test",

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -24,7 +24,7 @@ import unittest
 from pathlib import Path
 
 import pandas as pd
-from google.cloud import bigquery, storage
+from google.cloud import bigquery
 
 from lsst.dax.apdb import Apdb, ApdbReplica, ApdbTables
 from lsst.dax.ppdb import Ppdb
@@ -88,7 +88,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         # Create PPDB config with unique BQ dataset and GCS bucket.
         self.bq_client = bigquery.Client()
 
-        self.config = self.make_instance(test_name="test_promoter")
+        self.config = self.make_instance(test_name="test_chunk_promoter")
 
         # Create the PPDB instance.
         self.ppdb = Ppdb.from_config(self.config)
@@ -96,6 +96,9 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
 
         # Create the BigQuery datasets for the test.
         create_datasets(self.config)
+
+        # Add cleanup of datasets after test.
+        self.addCleanup(drop_datasets, self.config)
 
         # Replicate the APDB data into the PPDB, creating parquet files for
         # each chunk.
@@ -110,8 +113,10 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         replicator.run(exit_on_empty=True)
 
         # Create GCS bucket needed for storing parquet with update records.
-        create_bucket(self.config)
-        self.bucket = storage.Client().bucket(self.config.bucket_name)
+        self.bucket = create_bucket(self.config)
+
+        # Add cleanup for datasets and bucket after test.
+        self.addCleanup(delete_bucket, self.bucket)
 
         # Set chunk statuses and upload only the updates file to GCS. Table
         # data is loaded from local parquet files directly into BQ, bypassing
@@ -133,20 +138,6 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
             self.ppdb.update_chunks(
                 [chunk.with_new_status(status).with_new_gcs_uri(gcs_uri)], fields={"status", "gcs_uri"}
             )
-
-    def tearDown(self):
-        # Delete the BigQuery test datasets.
-        try:
-            drop_datasets(self.config)
-        except Exception as e:
-            print(f"Failed to delete test datasets: {e}")
-
-        # Delete the GCS test bucket.
-        try:
-            delete_bucket(self.bucket)
-        except Exception as e:
-            print(f"Failed to delete test GCS bucket: {e}")
-        super().tearDown()
 
     def _load_parquet_to_table(self, parquet_path: Path, table_fqn: str) -> None:
         """Load a local parquet file into a BigQuery table, creating the table
@@ -336,12 +327,17 @@ class FillValidityEndTestCase(unittest.TestCase):
     scenarios.
     """
 
+    dataset_types = (DatasetType.INTERNAL, DatasetType.STAGING)
+
     def setUp(self):
         # Create the PPDB BigQuery config.
         self.config = make_bigquery_config(test_name="test_fill_validity_end")
 
         # Create the datasets.
-        create_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
+        create_datasets(self.config, self.dataset_types)
+
+        # Add cleanup of datasets after test.
+        self.addCleanup(drop_datasets, self.config, self.dataset_types)
 
         # Build table FQNs for the test tables.
         self.internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject_promoted_tmp")
@@ -371,13 +367,6 @@ class FillValidityEndTestCase(unittest.TestCase):
             )
             """
         ).result()
-
-    def tearDown(self):
-        # Delete test datasets.
-        try:
-            drop_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
-        except Exception:
-            self.fail("Failed to delete test datasets")
 
     def _insert_target_rows(self, rows: list[tuple]) -> None:
         """Insert rows into the internal table.

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -21,35 +21,35 @@
 
 import posixpath
 import unittest
-import uuid
 from pathlib import Path
 
 import pandas as pd
 from google.cloud import bigquery, storage
 
-from lsst.dax.apdb import Apdb, ApdbReplica
+from lsst.dax.apdb import Apdb, ApdbReplica, ApdbTables
 from lsst.dax.ppdb import Ppdb
 from lsst.dax.ppdb.bigquery import (
     ChunkPromoter,
     ChunkStatus,
+    DatasetType,
     Manifest,
     NoPromotableChunksError,
     PpdbBigQuery,
     PpdbReplicaChunkExtended,
-    TableRefs,
 )
 from lsst.dax.ppdb.bigquery.sql_resource import SqlResource
 from lsst.dax.ppdb.bigquery.updates import ExpandedUpdateRecord, UpdateRecordExpander, UpdateRecords
 from lsst.dax.ppdb.replicator import Replicator
-from lsst.dax.ppdb.tests import fill_apdb
-from lsst.dax.ppdb.tests._bigquery import (
+from lsst.dax.ppdb.tests import (
     PostgresMixin,
+    create_bucket,
+    create_datasets,
+    delete_datasets,
     delete_test_bucket,
-    generate_test_bucket_name,
+    fill_apdb,
     have_valid_google_credentials,
+    make_bigquery_config,
 )
-
-_TABLE_NAMES = ["DiaObject", "DiaSource", "DiaForcedSource"]
 
 
 @unittest.skipIf(not have_valid_google_credentials(), "Missing valid Google credentials")
@@ -61,6 +61,12 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
     staging). Only the parquet file containing update records is uploaded to
     GCS, as it is read directly during the promotion process.
     """
+
+    TABLE_NAMES = [
+        ApdbTables.DiaObject.value,
+        ApdbTables.DiaSource.value,
+        ApdbTables.DiaForcedSource.value,
+    ]
 
     def setUp(self):
         """Set up the test case.
@@ -81,29 +87,18 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
 
         # Create PPDB config with unique BQ dataset and GCS bucket.
         self.bq_client = bigquery.Client()
-        dataset_id = f"test_promoter_{uuid.uuid4().hex[:8]}"
-        project_id = self.bq_client.project
-        bucket_name = generate_test_bucket_name("ppdb-promoter-test")
-        config = {
-            "db_drop": True,
-            "validate_config": False,
-            "delete_existing_dirs": True,
-            "bucket_name": bucket_name,
-            "object_prefix": "data/test",
-            "dataset_id": dataset_id,
-            "project_id": project_id,
-        }
-        self.ppdb_config = self.make_instance(config)
-        self.target_dataset_fqn = f"{project_id}.{dataset_id}"
-        self._table_refs = TableRefs(
-            project_id=project_id,
-            dataset_id=dataset_id,
-            table_names=tuple(_TABLE_NAMES),
-        )
 
-        # Create the PPDB instance and replicate APDB data.
-        self.ppdb = Ppdb.from_config(self.ppdb_config)
+        self.config = self.make_instance(test_name="test_promoter")
+
+        # Create the PPDB instance.
+        self.ppdb = Ppdb.from_config(self.config)
         assert isinstance(self.ppdb, PpdbBigQuery)
+
+        # Create the BigQuery datasets for the test.
+        create_datasets(self.config)
+
+        # Replicate the APDB data into the PPDB, creating parquet files for
+        # each chunk.
         replicator = Replicator(
             apdb_replica,
             self.ppdb,
@@ -115,9 +110,8 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         replicator.run(exit_on_empty=True)
 
         # Create GCS bucket needed for storing parquet with update records.
-        storage_client = storage.Client()
-        self._bucket = storage_client.bucket(bucket_name)
-        self._bucket.create(location="US")
+        create_bucket(self.config)
+        self.bucket = storage.Client().bucket(self.config.bucket_name)
 
         # Set chunk statuses and upload only the updates file to GCS. Table
         # data is loaded from local parquet files directly into BQ, bypassing
@@ -129,30 +123,27 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
             manifest = Manifest.from_json_file(chunk_dir / Manifest.FILE_NAME)
             status = ChunkStatus.UPLOADED if manifest.has_table_data else ChunkStatus.STAGED
             gcs_prefix = posixpath.join(self.ppdb.config.object_prefix, str(chunk.id))
-            gcs_uri = f"gs://{bucket_name}/{gcs_prefix}"
+            gcs_uri = f"gs://{self.config.bucket_name}/{gcs_prefix}"
 
             update_records_path = chunk_dir / UpdateRecords.PARQUET_FILE_NAME
             if update_records_path.exists():
-                blob = self._bucket.blob(f"{gcs_prefix}/{UpdateRecords.PARQUET_FILE_NAME}")
+                blob = self.bucket.blob(f"{gcs_prefix}/{UpdateRecords.PARQUET_FILE_NAME}")
                 blob.upload_from_filename(str(update_records_path))
 
             self.ppdb.update_chunks(
                 [chunk.with_new_status(status).with_new_gcs_uri(gcs_uri)], fields={"status", "gcs_uri"}
             )
 
-        # Create the BQ dataset.
-        dataset = bigquery.Dataset(self.target_dataset_fqn)
-        self.bq_client.create_dataset(dataset, exists_ok=False)
-
     def tearDown(self):
+        # Delete the BigQuery test datasets.
         try:
-            self.bq_client.delete_dataset(
-                self.ppdb_config.dataset_id, delete_contents=True, not_found_ok=True
-            )
+            delete_datasets(self.config)
         except Exception as e:
-            print(f"Failed to delete test dataset: {e}")
+            print(f"Failed to delete test datasets: {e}")
+
+        # Delete the GCS test bucket.
         try:
-            delete_test_bucket(self._bucket)
+            delete_test_bucket(self.bucket)
         except Exception as e:
             print(f"Failed to delete test GCS bucket: {e}")
         super().tearDown()
@@ -172,30 +163,32 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
             )
             job.result()
 
-    def _create_empty_prod_tables(self, chunk: PpdbReplicaChunkExtended) -> None:
-        """Create empty prod tables by loading a chunk's parquet files
+    def _create_empty_internal_tables(self, chunk: PpdbReplicaChunkExtended) -> None:
+        """Create empty internal tables by loading a chunk's parquet files
         and then truncating them. This gives BigQuery the correct schema.
         """
-        for table_name, prod_ref in zip(_TABLE_NAMES, self._table_refs.prod, strict=True):
+        for table_name in self.TABLE_NAMES:
+            internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name)
             parquet_path = self.ppdb.config.chunk_dir(chunk.id) / f"{table_name}.parquet"
             if parquet_path.exists():
-                self._load_parquet_to_table(parquet_path, prod_ref)
-                self.bq_client.query(f"TRUNCATE TABLE `{prod_ref}`").result()
+                self._load_parquet_to_table(parquet_path, internal_table_fqn)
+                self.bq_client.query(f"TRUNCATE TABLE `{internal_table_fqn}`").result()
 
     def _load_chunk_to_staging(self, chunk: PpdbReplicaChunkExtended) -> None:
         """Load a chunk's parquet files into staging tables and add the
         ``apdb_replica_chunk`` column, simulating the Dataflow staging step.
         This mocks the cloud function which stages the data using Dataflow.
         """
-        for table_name, staging_ref in zip(_TABLE_NAMES, self._table_refs.staging, strict=True):
+        for table_name in self.TABLE_NAMES:
+            staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, table_name)
             parquet_path = self.ppdb.config.chunk_dir(chunk.id) / f"{table_name}.parquet"
             if parquet_path.exists():
-                self._load_parquet_to_table(parquet_path, staging_ref)
+                self._load_parquet_to_table(parquet_path, staging_table_fqn)
                 self.bq_client.query(
-                    f"ALTER TABLE `{staging_ref}` ADD COLUMN IF NOT EXISTS apdb_replica_chunk INT64"
+                    f"ALTER TABLE `{staging_table_fqn}` ADD COLUMN IF NOT EXISTS apdb_replica_chunk INT64"
                 ).result()
                 self.bq_client.query(
-                    f"UPDATE `{staging_ref}` SET apdb_replica_chunk = {chunk.id} WHERE "
+                    f"UPDATE `{staging_table_fqn}` SET apdb_replica_chunk = {chunk.id} WHERE "
                     f"apdb_replica_chunk IS NULL"
                 ).result()
 
@@ -227,11 +220,11 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         staging_rows: dict[str, list[dict]],
         expanded_updates: list[ExpandedUpdateRecord],
     ) -> None:
-        """Verify promoted prod data matches staging data with updates applied.
+        """Verify promoted data matches staging data with updates applied.
 
         For each table, builds an expected DataFrame from the staging snapshot
-        with update records applied, then compares it against the actual prod
-        DataFrame.
+        with update records applied, then compares it against the actual
+        internal DataFrame.
         """
         # Keys used by MERGE SQL to match update records to rows.
         merge_match_keys: dict[str, tuple[str, ...]] = {
@@ -246,9 +239,7 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         unique_row_keys = dict(merge_match_keys)
         unique_row_keys["DiaObject"] = ("diaObjectId", "validityStartMjdTai")
 
-        for table_name, prod_table_ref in zip(
-            self._table_refs.table_names, self._table_refs.prod, strict=True
-        ):
+        for table_name in self.TABLE_NAMES:
             sort_columns = list(unique_row_keys[table_name])
             match_columns = list(merge_match_keys[table_name])
 
@@ -267,8 +258,9 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
 
             # Convert to DataFrames, sort, and compare.
             expected = pd.DataFrame(expected_rows).sort_values(sort_columns).reset_index(drop=True)
+            internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, table_name)
             actual = (
-                pd.DataFrame(self._query_table(prod_table_ref))
+                pd.DataFrame(self._query_table(internal_table_fqn))
                 .sort_values(sort_columns)
                 .reset_index(drop=True)
             )
@@ -283,19 +275,20 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         data_chunks = [c for c in all_chunks if c.status == ChunkStatus.UPLOADED]
         self.assertTrue(data_chunks, "Expected at least one data chunk")
 
-        # Create empty prod tables (promoter clones them for the tmp tables).
-        self._create_empty_prod_tables(data_chunks[0])
+        # Create empty internal tables from parquet data.
+        self._create_empty_internal_tables(data_chunks[0])
 
-        # Stage all data chunks (simulating the Dataflow staging step).
+        # Stage all data chunks, simulating the Dataflow staging step.
         for chunk in data_chunks:
             self._load_chunk_to_staging(chunk)
             self.ppdb.update_chunks([chunk.with_new_status(ChunkStatus.STAGED)], fields={"status"})
 
         # Snapshot the staged rows per table before promotion.
         staging_rows: dict[str, list[dict]] = {}
-        for table_name, staging_ref in zip(_TABLE_NAMES, self._table_refs.staging, strict=True):
-            if self._table_exists(staging_ref):
-                staging_rows[table_name] = self._query_table(staging_ref)
+        for table_name in self.TABLE_NAMES:
+            staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, table_name)
+            if self._table_exists(staging_table_fqn):
+                staging_rows[table_name] = self._query_table(staging_table_fqn)
 
         # Expand update records before promotion for later verification.
         expanded_updates = self._get_expanded_updates()
@@ -306,13 +299,15 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         promoter.promote_chunks(chunks_to_promote)
 
         # Verify staging tables are empty.
-        for staging_ref in self._table_refs.staging:
-            if self._table_exists(staging_ref):
-                rows = self._query_table(staging_ref)
-                self.assertEqual(len(rows), 0, f"{staging_ref} should be empty")
+        for table_name in self.TABLE_NAMES:
+            staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, table_name)
+            if self._table_exists(staging_table_fqn):
+                rows = self._query_table(staging_table_fqn)
+                self.assertEqual(len(rows), 0, f"{staging_table_fqn} should be empty")
 
         # Verify tmp tables were cleaned up.
-        for tmp_ref in self._table_refs.promoted_tmp:
+        for table_name in self.TABLE_NAMES:
+            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, f"{table_name}_promoted_tmp")
             self.assertFalse(self._table_exists(tmp_ref), f"{tmp_ref} should not exist")
 
         # Verify all chunks are marked PROMOTED.
@@ -342,25 +337,22 @@ class FillValidityEndTestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        # Create the PPDB BigQuery config.
+        self.config = make_bigquery_config(test_name="test_fill_validity_end")
+
+        # Create the datasets.
+        create_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
+
+        # Build table FQNs for the test tables.
+        self.internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject_promoted_tmp")
+        self.staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, "DiaObject")
+
         self.bq_client = bigquery.Client()
-        self.project_id = self.bq_client.project
-        self.dataset_id = f"test_fill_validity_end_{uuid.uuid4().hex[:8]}"
-        self.dataset_fqn = f"{self.project_id}.{self.dataset_id}"
-
-        # Create the dataset.
-        dataset = bigquery.Dataset(self.dataset_fqn)
-        self.bq_client.create_dataset(dataset, exists_ok=False)
-
-        # Table FQNs matching the format used by ChunkPromoter.
-        self.target_table = f"{self.dataset_id}._DiaObject_promoted_tmp"
-        self.staging_table = f"{self.dataset_id}._DiaObject_staging"
-        self.target_fqn = f"{self.project_id}.{self.target_table}"
-        self.staging_fqn = f"{self.project_id}.{self.staging_table}"
 
         # Create target table (promoted_tmp).
         self.bq_client.query(
             f"""
-            CREATE TABLE `{self.target_fqn}` (
+            CREATE TABLE `{self.internal_table_fqn}` (
                 diaObjectId INT64,
                 validityStartMjdTai FLOAT64,
                 validityEndMjdTai FLOAT64
@@ -371,7 +363,7 @@ class FillValidityEndTestCase(unittest.TestCase):
         # Create staging table.
         self.bq_client.query(
             f"""
-            CREATE TABLE `{self.staging_fqn}` (
+            CREATE TABLE `{self.staging_table_fqn}` (
                 diaObjectId INT64,
                 validityStartMjdTai FLOAT64,
                 validityEndMjdTai FLOAT64,
@@ -381,10 +373,14 @@ class FillValidityEndTestCase(unittest.TestCase):
         ).result()
 
     def tearDown(self):
-        self.bq_client.delete_dataset(self.dataset_id, delete_contents=True, not_found_ok=True)
+        # Delete test datasets.
+        try:
+            delete_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
+        except Exception:
+            self.fail("Failed to delete test datasets")
 
     def _insert_target_rows(self, rows: list[tuple]) -> None:
-        """Insert rows into the target table.
+        """Insert rows into the internal table.
 
         Each row is (diaObjectId, validityStartMjdTai, validityEndMjdTai).
         """
@@ -392,7 +388,7 @@ class FillValidityEndTestCase(unittest.TestCase):
             return
         values = ", ".join(f"({r[0]}, {r[1]}, {'NULL' if r[2] is None else r[2]})" for r in rows)
         self.bq_client.query(
-            f"INSERT INTO `{self.target_fqn}` (diaObjectId, validityStartMjdTai, validityEndMjdTai) "
+            f"INSERT INTO `{self.internal_table_fqn}` (diaObjectId, validityStartMjdTai, validityEndMjdTai) "
             f"VALUES {values}"
         ).result()
 
@@ -406,7 +402,7 @@ class FillValidityEndTestCase(unittest.TestCase):
             return
         values = ", ".join(f"({r[0]}, {r[1]}, {'NULL' if r[2] is None else r[2]}, {r[3]})" for r in rows)
         self.bq_client.query(
-            f"INSERT INTO `{self.staging_fqn}` "
+            f"INSERT INTO `{self.staging_table_fqn}` "
             f"(diaObjectId, validityStartMjdTai, validityEndMjdTai, apdb_replica_chunk) "
             f"VALUES {values}"
         ).result()
@@ -416,8 +412,8 @@ class FillValidityEndTestCase(unittest.TestCase):
         sql = SqlResource(
             "fill_diaobject_validity_end",
             format_args={
-                "target_table": self.target_table,
-                "staging_table": self.staging_table,
+                "target_table": self.internal_table_fqn,
+                "staging_table": self.staging_table_fqn,
             },
         ).sql
         self.bq_client.query(sql).result()
@@ -428,7 +424,7 @@ class FillValidityEndTestCase(unittest.TestCase):
         """
         rows = self.bq_client.query(
             f"SELECT diaObjectId, validityStartMjdTai, validityEndMjdTai "
-            f"FROM `{self.target_fqn}` ORDER BY diaObjectId, validityStartMjdTai"
+            f"FROM `{self.internal_table_fqn}` ORDER BY diaObjectId, validityStartMjdTai"
         ).result()
         return [dict(row) for row in rows]
 

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -44,8 +44,8 @@ from lsst.dax.ppdb.tests import (
     PostgresMixin,
     create_bucket,
     create_datasets,
-    delete_datasets,
-    delete_test_bucket,
+    delete_bucket,
+    drop_datasets,
     fill_apdb,
     have_valid_google_credentials,
     make_bigquery_config,
@@ -137,13 +137,13 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
     def tearDown(self):
         # Delete the BigQuery test datasets.
         try:
-            delete_datasets(self.config)
+            drop_datasets(self.config)
         except Exception as e:
             print(f"Failed to delete test datasets: {e}")
 
         # Delete the GCS test bucket.
         try:
-            delete_test_bucket(self.bucket)
+            delete_bucket(self.bucket)
         except Exception as e:
             print(f"Failed to delete test GCS bucket: {e}")
         super().tearDown()
@@ -375,7 +375,7 @@ class FillValidityEndTestCase(unittest.TestCase):
     def tearDown(self):
         # Delete test datasets.
         try:
-            delete_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
+            drop_datasets(self.config, [DatasetType.INTERNAL, DatasetType.STAGING])
         except Exception:
             self.fail("Failed to delete test datasets")
 

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -94,11 +94,11 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
         self.ppdb = Ppdb.from_config(self.config)
         assert isinstance(self.ppdb, PpdbBigQuery)
 
-        # Create the BigQuery datasets for the test.
-        create_datasets(self.config)
-
         # Add cleanup of datasets after test.
         self.addCleanup(drop_datasets, self.config)
+
+        # Create the BigQuery datasets for the test.
+        create_datasets(self.config)
 
         # Replicate the APDB data into the PPDB, creating parquet files for
         # each chunk.

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -23,8 +23,6 @@ import hashlib
 import unittest
 from unittest.mock import patch
 
-from google.cloud import storage
-
 from lsst.dax.apdb import Apdb, ApdbReplica
 from lsst.dax.ppdb import Ppdb
 from lsst.dax.ppdb.bigquery import Manifest, PpdbBigQuery
@@ -34,8 +32,8 @@ from lsst.dax.ppdb.replicator import Replicator
 from lsst.dax.ppdb.tests import fill_apdb
 from lsst.dax.ppdb.tests._bigquery import (
     PostgresMixin,
+    create_bucket,
     delete_test_bucket,
-    generate_test_bucket_name,
     have_valid_google_credentials,
 )
 
@@ -54,9 +52,11 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         apdb_replica = ApdbReplica.from_config(apdb_config)
 
         # Make PPDB instance.
-        self.ppdb_config = self.make_instance()
+        self.ppdb_config = self.make_instance(test_name="test_chunk_uploader")
         self.ppdb = Ppdb.from_config(self.ppdb_config)
         assert isinstance(self.ppdb, PpdbBigQuery)
+
+        create_bucket(self.ppdb_config)
 
         # Replicate APDB replica chunks to the PPDB.
         replicator = Replicator(
@@ -64,16 +64,14 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         )
         replicator.run(exit_on_empty=True)
 
-        # Create a unique test bucket name and set up GCS resources.
-        self.ppdb_config.bucket_name = generate_test_bucket_name("ppdb-test-gcs-upload")
-        self._storage_client = storage.Client()
-        self._bucket = self._storage_client.bucket(self.ppdb_config.bucket_name)
-        self._bucket.create(location="US")
-
     def tearDown(self):
         # Delete the test GCS bucket.
-        delete_test_bucket(self._bucket)
-        super().tearDown()
+        try:
+            delete_test_bucket(self._bucket)
+        except Exception:
+            self.fail("Failed to delete test GCS bucket")
+        finally:
+            super().tearDown()
 
     def test_chunk_uploader(self) -> None:
         """Test that the update records are correctly uploaded to Google Cloud

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -56,7 +56,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         self.ppdb = Ppdb.from_config(self.ppdb_config)
         assert isinstance(self.ppdb, PpdbBigQuery)
 
-        create_bucket(self.ppdb_config)
+        self.bucket = create_bucket(self.ppdb_config)
 
         # Replicate APDB replica chunks to the PPDB.
         replicator = Replicator(
@@ -67,7 +67,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
     def tearDown(self):
         # Delete the test GCS bucket.
         try:
-            delete_bucket(self._bucket)
+            delete_bucket(self.bucket)
         except Exception:
             self.fail("Failed to delete test GCS bucket")
         finally:
@@ -88,7 +88,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
             ).run()
 
         # Retrieve the update records file.
-        blobs = list(self._bucket.list_blobs(match_glob="**/update_records.parquet"))
+        blobs = list(self.bucket.list_blobs(match_glob="**/update_records.parquet"))
         update_records_files = [b.name for b in blobs]
         self.assertEqual(
             len(update_records_files),
@@ -136,7 +136,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
             f"{update_records_files}",
         )
 
-        manifest_blob = self._bucket.blob(f"{expected_prefix}/{Manifest.FILE_NAME}")
+        manifest_blob = self.bucket.blob(f"{expected_prefix}/{Manifest.FILE_NAME}")
         self.assertTrue(manifest_blob.exists())
         manifest = Manifest.from_json_str(manifest_blob.download_as_text())
 
@@ -146,7 +146,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
         )
 
         updates_data = manifest.files[UpdateRecords.PARQUET_FILE_NAME]
-        local_update_path = self.ppdb.config.chunk_dir(uploaded_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
+        local_update_path = self.ppdb.config.chunk_dir(matched_chunk.id) / UpdateRecords.PARQUET_FILE_NAME
         expected_checksum = hashlib.sha256(local_update_path.read_bytes()).hexdigest()
         self.assertEqual(
             updates_data.checksum,

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -33,7 +33,7 @@ from lsst.dax.ppdb.tests import fill_apdb
 from lsst.dax.ppdb.tests._bigquery import (
     PostgresMixin,
     create_bucket,
-    delete_test_bucket,
+    delete_bucket,
     have_valid_google_credentials,
 )
 
@@ -67,7 +67,7 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
     def tearDown(self):
         # Delete the test GCS bucket.
         try:
-            delete_test_bucket(self._bucket)
+            delete_bucket(self._bucket)
         except Exception:
             self.fail("Failed to delete test GCS bucket")
         finally:

--- a/tests/test_chunk_uploader.py
+++ b/tests/test_chunk_uploader.py
@@ -58,20 +58,14 @@ class ChunkUploaderTestCase(PostgresMixin, unittest.TestCase):
 
         self.bucket = create_bucket(self.ppdb_config)
 
+        # Add cleanup for bucket after test.
+        self.addCleanup(delete_bucket, self.bucket)
+
         # Replicate APDB replica chunks to the PPDB.
         replicator = Replicator(
             apdb_replica, self.ppdb, update=False, min_wait_time=0, max_wait_time=0, check_interval=0
         )
         replicator.run(exit_on_empty=True)
-
-    def tearDown(self):
-        # Delete the test GCS bucket.
-        try:
-            delete_bucket(self.bucket)
-        except Exception:
-            self.fail("Failed to delete test GCS bucket")
-        finally:
-            super().tearDown()
 
     def test_chunk_uploader(self) -> None:
         """Test that the update records are correctly uploaded to Google Cloud

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,23 +22,20 @@
 from __future__ import annotations
 
 import os
-import sys
 import tempfile
 import unittest
-import uuid
 
 import yaml
 from google.cloud import bigquery
 
 from lsst.dax.ppdb.bigquery.ppdb_bigquery_config import (
-    Datasets,
     DatasetType,
-    PpdbBigQueryConfig,
 )
 from lsst.dax.ppdb.cli import ppdb_cli
-from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests._bigquery import (
+    drop_datasets,
     have_valid_google_credentials,
+    make_bigquery_config,
     search_indexes_enabled,
 )
 
@@ -49,49 +46,29 @@ class CreateDatasetsTestCase(unittest.TestCase):
 
     def setUp(self) -> None:
         self.client = bigquery.Client()
-        self.project_id = self.client.project
 
-        # Use unique dataset names so concurrent or repeated test runs do not
-        # collide with one another.
-        suffix = uuid.uuid4().hex[:8]
-        self.datasets = Datasets(
-            internal=f"test_cli_internal_{suffix}",
-            public=f"test_cli_public_{suffix}",
-            staging=f"test_cli_staging_{suffix}",
-        )
-
-        config = PpdbBigQueryConfig(
-            project_id=self.project_id,
-            dataset_id="dummy",  # TODO: This will be removed in DM-54681.
-            bucket_name="test-bucket",
-            object_prefix="data/test",
-            replication_dir="/tmp",
-            sql=PpdbSqlBaseConfig(db_url="sqlite:///:memory:"),
-            datasets=self.datasets,
-        )
+        self.config = make_bigquery_config(test_name="test_cli_create_datasets")
 
         # Serialize the configuration to a YAML file that the CLI can load.
         self.tempdir = tempfile.mkdtemp()
         self.config_path = os.path.join(self.tempdir, "ppdb_config.yaml")
-        config_dict = config.model_dump(exclude_unset=True, exclude_defaults=True)
+        config_dict = self.config.model_dump(exclude_unset=True, exclude_defaults=True)
         config_dict["implementation_type"] = "bigquery"
         with open(self.config_path, "w") as config_file:
             yaml.dump(config_dict, config_file)
 
     def tearDown(self) -> None:
-        for dataset_type in DatasetType:
-            dataset_name = self.datasets.name_for(dataset_type)
-            dataset_fqn = f"{self.project_id}.{dataset_name}"
-            try:
-                self.client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
-            except Exception as e:
-                print(f"Failed to delete {dataset_fqn}: {type(e).__name__}: {e}", file=sys.stderr)
+        try:
+            drop_datasets(self.config)
+        except Exception:
+            self.fail("Failed to delete test datasets")
 
     def test_create_datasets(self) -> None:
         """Test that ``ppdb-cli create-datasets`` creates the BigQuery
         datasets described by the configuration file.
         """
         argv = ["create-datasets", self.config_path]
+
         # Avoid exhausting BigQuery search index creation quotas unless
         # explicitly enabled for the test run.
         if not search_indexes_enabled():
@@ -102,9 +79,9 @@ class CreateDatasetsTestCase(unittest.TestCase):
         # Verify that the datasets were created in BigQuery with the correct
         # number of tables.
         for dataset_type in DatasetType:
-            dataset_name = self.datasets.name_for(dataset_type)
-            self.client.get_dataset(f"{self.project_id}.{dataset_name}")
-            tables = list(self.client.list_tables(f"{self.project_id}.{dataset_name}"))
+            dataset_fqn = self.config.fqn_for(dataset_type)
+            self.client.get_dataset(dataset_fqn)
+            tables = list(self.client.list_tables(dataset_fqn))
             self.assertEqual(len(tables), 3)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,11 +57,8 @@ class CreateDatasetsTestCase(unittest.TestCase):
         with open(self.config_path, "w") as config_file:
             yaml.dump(config_dict, config_file)
 
-    def tearDown(self) -> None:
-        try:
-            drop_datasets(self.config)
-        except Exception:
-            self.fail("Failed to delete test datasets")
+        # Add cleanup of datasets after test.
+        self.addCleanup(drop_datasets, self.config)
 
     def test_create_datasets(self) -> None:
         """Test that ``ppdb-cli create-datasets`` creates the BigQuery

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -93,7 +93,6 @@ class DatasetBuilderTestMixin:
         """
         return PpdbBigQueryConfig(
             project_id=project_id,
-            dataset_id="test_dataset_builder",
             bucket_name="test-bucket",
             object_prefix="data/test",
             replication_dir="/tmp",

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -21,7 +21,6 @@
 
 from __future__ import annotations
 
-import sys
 import unittest
 import uuid
 from unittest.mock import Mock, patch
@@ -51,6 +50,7 @@ from lsst.dax.ppdb.bigquery.schema.dataset_builder import (
 from lsst.dax.ppdb.bigquery.schema.felis_converter import FelisConverter
 from lsst.dax.ppdb.sql import PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests._bigquery import (
+    drop_datasets,
     have_valid_google_credentials,
     search_indexes_enabled,
 )
@@ -693,14 +693,8 @@ class DatasetBuilderBigQueryTestCase(unittest.TestCase):
             datasets=self.datasets,
         )
 
-    def tearDown(self) -> None:
-        for dataset_type in DatasetType:
-            dataset_name = self.datasets.name_for(dataset_type)
-            dataset_fqn = f"{self.project_id}.{dataset_name}"
-            try:
-                self.client.delete_dataset(dataset_fqn, delete_contents=True, not_found_ok=True)
-            except Exception as e:
-                print(f"Failed to delete {dataset_fqn}: {type(e).__name__}: {e}", file=sys.stderr)
+        # Clean up datasets after tests.
+        self.addCleanup(drop_datasets, self.config)
 
     def test_build_datasets_creates_expected_bigquery_objects(self) -> None:
         """Test that build_datasets creates expected tables and views.

--- a/tests/test_felis_converter.py
+++ b/tests/test_felis_converter.py
@@ -90,12 +90,12 @@ class FelisConverterTestCase(unittest.TestCase):
         )
 
         converter = FelisConverter(schema)
-        converted = converter.convert_tables(["TypeCoverage"], "test-project.test_dataset")
+        converted = converter.convert_tables(["TypeCoverage"], "dummy-project.dummy_dataset")
 
         self.assertEqual(len(converted), 1)
         bq_table = converted[0]
-        self.assertEqual(bq_table.project, "test-project")
-        self.assertEqual(bq_table.dataset_id, "test_dataset")
+        self.assertEqual(bq_table.project, "dummy-project")
+        self.assertEqual(bq_table.dataset_id, "dummy_dataset")
         self.assertEqual(bq_table.table_id, "TypeCoverage")
 
         self.assertEqual(len(bq_table.schema), len(columns))
@@ -112,7 +112,7 @@ class FelisConverterTestCase(unittest.TestCase):
     def test_convert_tables_raises_for_missing_name(self) -> None:
         """convert_tables should surface missing table lookup failures."""
         with self.assertRaisesRegex(FelisConverterError, r"Table 'MissingTable' not found"):
-            self.converter.convert_tables(["MissingTable"], "test-project.test_dataset")
+            self.converter.convert_tables(["MissingTable"], "dummy-project.dummy_dataset")
 
 
 if __name__ == "__main__":

--- a/tests/test_ppdb_bigquery.py
+++ b/tests/test_ppdb_bigquery.py
@@ -72,7 +72,7 @@ def _make_chunk(
     )
 
 
-class ReplicaChunkTestCase(SqliteMixin, unittest.TestCase):
+class PpdbBigQueryTestCase(SqliteMixin, unittest.TestCase):
     """Tests for replica chunk database operations."""
 
     def _make_ppdb(self) -> PpdbBigQuery:

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -241,3 +241,122 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             self.ppdb.chunk_table.columns["apdb_replica_chunk"].in_([test_replica_chunk_id])
         )
         updates_manager.apply_updates(replica_chunks)
+
+        client = bigquery.Client()
+
+        # Verify DiaSource updates.
+        dia_source_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaSource")
+        rows = client.query(
+            f"""
+            SELECT
+              diaSourceId,
+              diaObjectId,
+              ssObjectId,
+              ssObjectReassocTimeMjdTai,
+              timeWithdrawnMjdTai
+            FROM `{dia_source_fqn}`
+            WHERE diaSourceId IN (100001, 100002, 100003, 100004)
+            """
+        ).result()
+
+        dia_sources = {row["diaSourceId"]: row for row in rows}
+
+        self.assertEqual(set(dia_sources), {100001, 100002, 100003, 100004})
+
+        # Latest reassign record should win: 400001, not 300001.
+        self.assertEqual(dia_sources[100001]["diaObjectId"], 400001)
+        self.assertIsNone(dia_sources[100001]["ssObjectId"])
+        self.assertIsNone(dia_sources[100001]["ssObjectReassocTimeMjdTai"])
+        self.assertIsNone(dia_sources[100001]["timeWithdrawnMjdTai"])
+
+        # Reassigned to SSObject.
+        self.assertEqual(dia_sources[100002]["ssObjectId"], 2001)
+        self.assertEqual(
+            dia_sources[100002]["ssObjectReassocTimeMjdTai"],
+            59580.0,
+        )
+        self.assertIsNone(dia_sources[100002]["timeWithdrawnMjdTai"])
+
+        # Withdrawn DiaSource.
+        self.assertEqual(
+            dia_sources[100003]["timeWithdrawnMjdTai"],
+            59580.0,
+        )
+
+        # Unaffected DiaSource should remain unchanged.
+        self.assertEqual(dia_sources[100004]["diaObjectId"], 200004)
+        self.assertIsNone(dia_sources[100004]["ssObjectId"])
+        self.assertIsNone(dia_sources[100004]["ssObjectReassocTimeMjdTai"])
+        self.assertIsNone(dia_sources[100004]["timeWithdrawnMjdTai"])
+
+        # Verify DiaForcedSource updates.
+        dia_forced_source_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaForcedSource")
+        rows = client.query(
+            f"""
+            SELECT
+              diaObjectId,
+              visit,
+              detector,
+              timeWithdrawnMjdTai
+            FROM `{dia_forced_source_fqn}`
+            WHERE diaObjectId = 200001
+              AND visit IN (12345, 12346)
+              AND detector = 42
+            """
+        ).result()
+
+        forced_sources = {(row["diaObjectId"], row["visit"], row["detector"]): row for row in rows}
+
+        self.assertEqual(
+            set(forced_sources),
+            {
+                (200001, 12345, 42),
+                (200001, 12346, 42),
+            },
+        )
+
+        # Withdrawn DiaForcedSource.
+        self.assertEqual(
+            forced_sources[(200001, 12345, 42)]["timeWithdrawnMjdTai"],
+            59580.0,
+        )
+
+        # Unaffected DiaForcedSource should remain unchanged.
+        self.assertIsNone(
+            forced_sources[(200001, 12346, 42)]["timeWithdrawnMjdTai"],
+        )
+
+        # Verify DiaObject updates.
+        dia_object_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaObject")
+        rows = client.query(
+            f"""
+            SELECT
+              diaObjectId,
+              validityEndMjdTai,
+              nDiaSources
+            FROM `{dia_object_fqn}`
+            WHERE diaObjectId IN (200001, 200002, 200003)
+            """
+        ).result()
+
+        dia_objects = {row["diaObjectId"]: row for row in rows}
+
+        self.assertEqual(set(dia_objects), {200001, 200002, 200003})
+
+        # Closed validity interval.
+        self.assertEqual(
+            dia_objects[200001]["validityEndMjdTai"],
+            59580.0,
+        )
+        self.assertEqual(dia_objects[200001]["nDiaSources"], 5)
+
+        # Latest nDiaSources update should win: 10, not older value 8.
+        self.assertIsNone(dia_objects[200002]["validityEndMjdTai"])
+        self.assertEqual(dia_objects[200002]["nDiaSources"], 10)
+
+        # Unaffected DiaObject should remain unchanged.
+        self.assertEqual(
+            dia_objects[200003]["validityEndMjdTai"],
+            59000.0,
+        )
+        self.assertEqual(dia_objects[200003]["nDiaSources"], 2)

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -43,7 +43,7 @@ from lsst.dax.ppdb.bigquery.updates.updates_manager import UpdatesManager
 from lsst.dax.ppdb.tests._bigquery import (
     PostgresMixin,
     create_datasets,
-    delete_test_bucket,
+    delete_bucket,
     have_valid_google_credentials,
     json_rows_to_buf,
 )
@@ -93,7 +93,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
 
         # Delete the test GCS bucket.
         try:
-            delete_test_bucket(self.ppdb.config)
+            delete_bucket(self.ppdb.config)
         except Exception as e:
             self.fail(f"Failed to delete test GCS bucket: {e}")
 

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -66,11 +66,11 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         # Setup the Postgres database and create the config instance.
         self.config = self.make_instance(test_name="test_updates_manager")
 
-        # Create the necessary datasets in BigQuery for the test.
-        create_datasets(self.config, self.dataset_types)
-
         # Add cleanup for datasets after test.
         self.addCleanup(drop_datasets, self.config, self.dataset_types)
+
+        # Create the necessary datasets in BigQuery for the test.
+        create_datasets(self.config, self.dataset_types)
 
         # Create the test tables in BigQuery.
         self._create_test_tables(self.config, DatasetType.INTERNAL)

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 
 import astropy
 import felis
-from google.cloud import bigquery, storage
+from google.cloud import bigquery
 
 from lsst.dax.apdb import (
     ApdbTableData,
@@ -42,8 +42,10 @@ from lsst.dax.ppdb.bigquery.chunk_uploader import ChunkUploader
 from lsst.dax.ppdb.bigquery.updates.updates_manager import UpdatesManager
 from lsst.dax.ppdb.tests._bigquery import (
     PostgresMixin,
+    create_bucket,
     create_datasets,
     delete_bucket,
+    drop_datasets,
     have_valid_google_credentials,
     json_rows_to_buf,
 )
@@ -56,48 +58,32 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
     related classes including the ChunkUploader.
     """
 
+    dataset_types = (DatasetType.INTERNAL, DatasetType.STAGING)
+
     def setUp(self):
         super().setUp()
 
         # Setup the Postgres database and create the config instance.
-        config = self.make_instance(test_name="test_updates_manager")
+        self.config = self.make_instance(test_name="test_updates_manager")
 
         # Create the necessary datasets in BigQuery for the test.
-        create_datasets(config, [DatasetType.INTERNAL, DatasetType.STAGING])
+        create_datasets(self.config, self.dataset_types)
+
+        # Add cleanup for datasets after test.
+        self.addCleanup(drop_datasets, self.config, self.dataset_types)
 
         # Create the test tables in BigQuery.
-        self._create_test_tables(config, DatasetType.INTERNAL)
+        self._create_test_tables(self.config, DatasetType.INTERNAL)
 
         # Create the test GCS bucket.
-        storage_client = storage.Client()
-        try:
-            bucket = storage_client.bucket(config.bucket_name)
-            bucket.create(location="US")
-        except Exception as e:
-            self.fail(f"Failed to create test GCS bucket: {e}")
+        create_bucket(self.config)
+
+        # Add cleanup for the bucket after test.
+        self.addCleanup(delete_bucket, self.config.bucket_name)
 
         # Create the PPDB instance.
-        self.ppdb = Ppdb.from_config(config)
+        self.ppdb = Ppdb.from_config(self.config)
         assert isinstance(self.ppdb, PpdbBigQuery)
-
-    def tearDown(self):
-        # Delete the test dataset.
-        client = bigquery.Client()
-        for dataset_type in [DatasetType.INTERNAL, DatasetType.STAGING]:
-            try:
-                client.delete_dataset(
-                    self.ppdb.config.datasets.name_for(dataset_type), delete_contents=True, not_found_ok=True
-                )
-            except Exception as e:
-                self.fail(f"Failed to delete test dataset: {e}")
-
-        # Delete the test GCS bucket.
-        try:
-            delete_bucket(self.ppdb.config)
-        except Exception as e:
-            self.fail(f"Failed to delete test GCS bucket: {e}")
-
-        super().tearDown()
 
     @staticmethod
     def _create_test_tables(config: PpdbBigQueryConfig, dataset_type: DatasetType) -> None:

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -33,12 +33,17 @@ from lsst.dax.apdb import (
     ReplicaChunk,
 )
 from lsst.dax.ppdb import Ppdb
-from lsst.dax.ppdb.bigquery import PpdbBigQuery
+from lsst.dax.ppdb.bigquery import (
+    DatasetType,
+    PpdbBigQuery,
+    PpdbBigQueryConfig,
+)
 from lsst.dax.ppdb.bigquery.chunk_uploader import ChunkUploader
 from lsst.dax.ppdb.bigquery.updates.updates_manager import UpdatesManager
 from lsst.dax.ppdb.tests._bigquery import (
     PostgresMixin,
-    generate_test_bucket_name,
+    create_datasets,
+    delete_test_bucket,
     have_valid_google_credentials,
     json_rows_to_buf,
 )
@@ -54,66 +59,50 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        # Set up BigQuery client and test dataset.
-        self.bq_client = bigquery.Client()
-
-        bucket_name = generate_test_bucket_name("ppdb-updates-manager-test")
-        dataset_id = f"test_updates_manager_{uuid.uuid4().hex[:8]}"
-        project_id = self.bq_client.project
-        config = {
-            "db_drop": True,
-            "validate_config": False,
-            "delete_existing_dirs": True,
-            "bucket_name": bucket_name,
-            "object_prefix": "data/test",
-            "dataset_id": dataset_id,
-            "project_id": project_id,
-        }
-
         # Setup the Postgres database and create the config instance.
-        self.ppdb_config = self.make_instance(config)
+        config = self.make_instance(test_name="test_updates_manager")
 
-        # Create the test dataset and tables in BigQuery.
-        self.target_dataset_fqn = f"{project_id}.{dataset_id}"
-        self._create_test_dataset(self.bq_client, dataset_id)
+        # Create the necessary datasets in BigQuery for the test.
+        create_datasets(config, [DatasetType.INTERNAL, DatasetType.STAGING])
+
+        # Create the test tables in BigQuery.
+        self._create_test_tables(config, DatasetType.INTERNAL)
 
         # Create the test GCS bucket.
         storage_client = storage.Client()
         try:
-            bucket = storage_client.bucket(self.ppdb_config.bucket_name)
+            bucket = storage_client.bucket(config.bucket_name)
             bucket.create(location="US")
         except Exception as e:
             self.fail(f"Failed to create test GCS bucket: {e}")
 
         # Create the PPDB instance.
-        self.ppdb = Ppdb.from_config(self.ppdb_config)
+        self.ppdb = Ppdb.from_config(config)
         assert isinstance(self.ppdb, PpdbBigQuery)
 
     def tearDown(self):
         # Delete the test dataset.
-        try:
-            self.bq_client.delete_dataset(
-                self.ppdb_config.dataset_id, delete_contents=True, not_found_ok=True
-            )
-        except Exception as e:
-            print(f"Failed to delete test dataset: {e}")
+        client = bigquery.Client()
+        for dataset_type in [DatasetType.INTERNAL, DatasetType.STAGING]:
+            try:
+                client.delete_dataset(
+                    self.ppdb.config.datasets.name_for(dataset_type), delete_contents=True, not_found_ok=True
+                )
+            except Exception as e:
+                self.fail(f"Failed to delete test dataset: {e}")
 
         # Delete the test GCS bucket.
-        storage_client = storage.Client()
         try:
-            bucket = storage_client.bucket(self.ppdb_config.bucket_name)
-            blobs = list(bucket.list_blobs())
-            for blob in blobs:
-                blob.delete()
-            bucket.delete()
+            delete_test_bucket(self.ppdb.config)
         except Exception as e:
-            print(f"Failed to delete test GCS bucket: {e}")
+            self.fail(f"Failed to delete test GCS bucket: {e}")
 
         super().tearDown()
 
-    def _create_test_dataset(self, client: bigquery.Client, dataset_id: str) -> None:
-        dataset = bigquery.Dataset(f"{client.project}.{dataset_id}")
-        client.create_dataset(dataset, exists_ok=False)
+    @staticmethod
+    def _create_test_tables(config: PpdbBigQueryConfig, dataset_type: DatasetType) -> None:
+        """Create test tables in the specified BigQuery dataset."""
+        client = bigquery.Client()
 
         # Create DiaObject table.
         schema = [
@@ -121,7 +110,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             bigquery.SchemaField("validityEndMjdTai", "FLOAT", mode="NULLABLE"),
             bigquery.SchemaField("nDiaSources", "INTEGER", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaObject"
+        table_fqn = config.fqn_for(dataset_type, "DiaObject")
         table = bigquery.Table(table_fqn, schema=schema)
         client.create_table(table)
         rows = [
@@ -145,9 +134,9 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             bigquery.SchemaField("ssObjectReassocTimeMjdTai", "FLOAT", mode="NULLABLE"),
             bigquery.SchemaField("timeWithdrawnMjdTai", "FLOAT", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaSource"
+        table_fqn = config.fqn_for(dataset_type, "DiaSource")
         table = bigquery.Table(table_fqn, schema=schema)
-        self.bq_client.create_table(table)
+        client.create_table(table)
         rows = [
             {
                 "diaSourceId": 100001,
@@ -192,14 +181,14 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
             bigquery.SchemaField("detector", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("timeWithdrawnMjdTai", "FLOAT", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaForcedSource"
+        table_fqn = config.fqn_for(dataset_type, "DiaForcedSource")
         table = bigquery.Table(table_fqn, schema=schema)
-        self.bq_client.create_table(table)
+        client.create_table(table)
         rows = [
             {"diaObjectId": 200001, "visit": 12345, "detector": 42, "timeWithdrawnMjdTai": None},
             {"diaObjectId": 200001, "visit": 12346, "detector": 42, "timeWithdrawnMjdTai": None},
         ]
-        job = self.bq_client.load_table_from_file(
+        job = client.load_table_from_file(
             json_rows_to_buf(rows),
             table_fqn,
             job_config=bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON),

--- a/tests/test_updates_merger.py
+++ b/tests/test_updates_merger.py
@@ -52,10 +52,10 @@ class TestUpdatesMerger(unittest.TestCase):
 
         self.config = make_bigquery_config("test_updates_merger")
 
-        create_datasets(self.config, self.dataset_types)
-
         # Add cleanup for datasets after test.
         self.addCleanup(drop_datasets, self.config, self.dataset_types)
+
+        create_datasets(self.config, self.dataset_types)
 
     def _create_target_table(self):
         schema = [

--- a/tests/test_updates_merger.py
+++ b/tests/test_updates_merger.py
@@ -20,13 +20,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import uuid
 
-try:
-    from google.cloud import bigquery
-except ImportError:
-    bigquery = None
+from google.cloud import bigquery
 
+from lsst.dax.ppdb.bigquery import DatasetType
 from lsst.dax.ppdb.bigquery.updates import (
     DiaForcedSourceUpdatesMerger,
     DiaObjectUpdatesMerger,
@@ -34,7 +31,13 @@ from lsst.dax.ppdb.bigquery.updates import (
     UpdateRecordExpander,
     UpdatesTable,
 )
-from lsst.dax.ppdb.tests._bigquery import have_valid_google_credentials, json_rows_to_buf
+from lsst.dax.ppdb.tests import (
+    create_datasets,
+    delete_datasets,
+    have_valid_google_credentials,
+    json_rows_to_buf,
+    make_bigquery_config,
+)
 from lsst.dax.ppdb.tests._updates import _create_test_update_records
 
 
@@ -44,17 +47,14 @@ class TestUpdatesMerger(unittest.TestCase):
 
     def setUp(self):
         self.client = bigquery.Client()
-        self.dataset_id = f"test_merger_{uuid.uuid4().hex[:8]}"
-        self.project_id = self.client.project
-        self.updates_table_fqn = f"{self.project_id}.{self.dataset_id}.updates"
-        self.target_dataset_fqn = f"{self.project_id}.{self.dataset_id}"
-        dataset = bigquery.Dataset(f"{self.project_id}.{self.dataset_id}")
-        dataset.default_table_expiration_ms = 3600000
-        self.client.create_dataset(dataset)
+
+        self.config = make_bigquery_config("test_updates_merger")
+
+        create_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
 
     def tearDown(self):
         try:
-            self.client.delete_dataset(self.dataset_id, delete_contents=True, not_found_ok=True)
+            delete_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
         except Exception:
             pass
 
@@ -64,7 +64,7 @@ class TestUpdatesMerger(unittest.TestCase):
             bigquery.SchemaField("validityEndMjdTai", "FLOAT", mode="NULLABLE"),
             bigquery.SchemaField("nDiaSources", "INTEGER", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaObject"
+        table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject")
         table = bigquery.Table(table_fqn, schema=schema)
         self.client.create_table(table)
         rows = [
@@ -82,20 +82,20 @@ class TestUpdatesMerger(unittest.TestCase):
 
     def test_merge_diaobject(self):
         self._create_target_table()
-        updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
+        updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
         updates_table.create()
         update_records = _create_test_update_records()
         expanded = UpdateRecordExpander.expand_updates(update_records, 0)
         updates_table.insert(expanded)
         updates_table.create_latest_only()
-        table_fqn = f"{self.target_dataset_fqn}.DiaObject"
+        table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject")
         query = f"SELECT * FROM `{table_fqn}` ORDER BY diaObjectId"
         before = {r.diaObjectId: r for r in self.client.query(query).result()}
         merger = DiaObjectUpdatesMerger()
         merger.merge(
             client=self.client,
             updates_table_fqn=updates_table.latest_only_table_fqn,
-            target_dataset_fqn=self.target_dataset_fqn,
+            target_dataset_fqn=self.config.fqn_for(DatasetType.INTERNAL),
         )
         after = {r.diaObjectId: r for r in self.client.query(query).result()}
         self.assertEqual(after[200001].validityEndMjdTai, 59580.0)
@@ -113,7 +113,7 @@ class TestUpdatesMerger(unittest.TestCase):
             bigquery.SchemaField("ssObjectReassocTimeMjdTai", "FLOAT", mode="NULLABLE"),
             bigquery.SchemaField("timeWithdrawnMjdTai", "FLOAT", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaSource"
+        table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaSource")
         table = bigquery.Table(table_fqn, schema=schema)
         self.client.create_table(table)
         rows = [
@@ -153,7 +153,7 @@ class TestUpdatesMerger(unittest.TestCase):
         )
         job.result()
 
-        updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
+        updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
         updates_table.create()
         update_records = _create_test_update_records()
         expanded = UpdateRecordExpander.expand_updates(update_records, 0)
@@ -166,7 +166,7 @@ class TestUpdatesMerger(unittest.TestCase):
         merger.merge(
             client=self.client,
             updates_table_fqn=updates_table.latest_only_table_fqn,
-            target_dataset_fqn=self.target_dataset_fqn,
+            target_dataset_fqn=self.config.fqn_for(DatasetType.INTERNAL),
         )
         after = {r.diaSourceId: r for r in self.client.query(query).result()}
 
@@ -185,7 +185,7 @@ class TestUpdatesMerger(unittest.TestCase):
             bigquery.SchemaField("detector", "INTEGER", mode="REQUIRED"),
             bigquery.SchemaField("timeWithdrawnMjdTai", "FLOAT", mode="NULLABLE"),
         ]
-        table_fqn = f"{self.target_dataset_fqn}.DiaForcedSource"
+        table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaForcedSource")
         table = bigquery.Table(table_fqn, schema=schema)
         self.client.create_table(table)
         rows = [
@@ -199,7 +199,7 @@ class TestUpdatesMerger(unittest.TestCase):
         )
         job.result()
 
-        updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
+        updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
         updates_table.create()
         update_records = _create_test_update_records()
         expanded = UpdateRecordExpander.expand_updates(update_records, 0)
@@ -212,7 +212,7 @@ class TestUpdatesMerger(unittest.TestCase):
         merger.merge(
             client=self.client,
             updates_table_fqn=updates_table.latest_only_table_fqn,
-            target_dataset_fqn=self.target_dataset_fqn,
+            target_dataset_fqn=self.config.fqn_for(DatasetType.INTERNAL),
         )
         after = {(r.diaObjectId, r.visit, r.detector): r for r in self.client.query(query).result()}
 
@@ -224,16 +224,16 @@ class TestUpdatesMerger(unittest.TestCase):
 
     def test_merge_no_updates(self):
         self._create_target_table()
-        updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
+        updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
         updates_table.create()
         updates_table.create_latest_only()
-        table_fqn = f"{self.target_dataset_fqn}.DiaObject"
+        table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject")
         before = {r.diaObjectId: r for r in self.client.query(f"SELECT * FROM `{table_fqn}`").result()}
         merger = DiaObjectUpdatesMerger()
         merger.merge(
             client=self.client,
             updates_table_fqn=updates_table.latest_only_table_fqn,
-            target_dataset_fqn=self.target_dataset_fqn,
+            target_dataset_fqn=self.config.fqn_for(DatasetType.INTERNAL),
         )
         after = {r.diaObjectId: r for r in self.client.query(f"SELECT * FROM `{table_fqn}`").result()}
         for obj_id in before:

--- a/tests/test_updates_merger.py
+++ b/tests/test_updates_merger.py
@@ -33,7 +33,7 @@ from lsst.dax.ppdb.bigquery.updates import (
 )
 from lsst.dax.ppdb.tests import (
     create_datasets,
-    delete_datasets,
+    drop_datasets,
     have_valid_google_credentials,
     json_rows_to_buf,
     make_bigquery_config,
@@ -54,7 +54,7 @@ class TestUpdatesMerger(unittest.TestCase):
 
     def tearDown(self):
         try:
-            delete_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
+            drop_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
         except Exception:
             pass
 

--- a/tests/test_updates_merger.py
+++ b/tests/test_updates_merger.py
@@ -45,18 +45,17 @@ from lsst.dax.ppdb.tests._updates import _create_test_update_records
 class TestUpdatesMerger(unittest.TestCase):
     """Test UpdatesMerger functionality."""
 
+    dataset_types = (DatasetType.INTERNAL, DatasetType.STAGING)
+
     def setUp(self):
         self.client = bigquery.Client()
 
         self.config = make_bigquery_config("test_updates_merger")
 
-        create_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
+        create_datasets(self.config, self.dataset_types)
 
-    def tearDown(self):
-        try:
-            drop_datasets(self.config, [DatasetType.STAGING, DatasetType.INTERNAL])
-        except Exception:
-            pass
+        # Add cleanup for datasets after test.
+        self.addCleanup(drop_datasets, self.config, self.dataset_types)
 
     def _create_target_table(self):
         schema = [

--- a/tests/test_updates_table.py
+++ b/tests/test_updates_table.py
@@ -38,6 +38,8 @@ from lsst.dax.ppdb.tests._updates import _create_test_update_records
 class TestUpdatesTable(unittest.TestCase):
     """Test UpdatesTable functionality."""
 
+    dataset_types = (DatasetType.STAGING,)
+
     def setUp(self) -> None:
         """Set up test fixtures."""
         # Create BigQuery client.
@@ -47,22 +49,16 @@ class TestUpdatesTable(unittest.TestCase):
         self.config = make_bigquery_config(test_name="test_updates_table")
 
         # Create the BigQuery dataset for the tests.
-        create_datasets(self.config, [DatasetType.STAGING])
+        create_datasets(self.config, self.dataset_types)
+
+        # Add cleanup for datasets after test.
+        self.addCleanup(drop_datasets, self.config, self.dataset_types)
 
         # Set the FQN of the updates table.
         self.table_fqn = self.config.fqn_for(DatasetType.STAGING, "updates")
 
         # Create the UpdatesTable instance.
         self.updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
-
-    def tearDown(self) -> None:
-        """Clean up test fixtures."""
-        # Always clean up the test dataset, whether test passed or failed.
-        try:
-            drop_datasets(self.config, [DatasetType.STAGING])
-        except Exception:
-            self.fail("Failed to delete test datasets")
-            raise
 
     def test_table_fqn_property(self) -> None:
         """Test the table_fqn property."""

--- a/tests/test_updates_table.py
+++ b/tests/test_updates_table.py
@@ -27,7 +27,7 @@ from lsst.dax.ppdb.bigquery import DatasetType
 from lsst.dax.ppdb.bigquery.updates import UpdateRecordExpander, UpdatesTable
 from lsst.dax.ppdb.tests import (
     create_datasets,
-    delete_datasets,
+    drop_datasets,
     have_valid_google_credentials,
     make_bigquery_config,
 )
@@ -59,7 +59,7 @@ class TestUpdatesTable(unittest.TestCase):
         """Clean up test fixtures."""
         # Always clean up the test dataset, whether test passed or failed.
         try:
-            delete_datasets(self.config, [DatasetType.STAGING])
+            drop_datasets(self.config, [DatasetType.STAGING])
         except Exception:
             self.fail("Failed to delete test datasets")
             raise

--- a/tests/test_updates_table.py
+++ b/tests/test_updates_table.py
@@ -20,12 +20,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import uuid
 
 from google.cloud import bigquery
 
+from lsst.dax.ppdb.bigquery import DatasetType
 from lsst.dax.ppdb.bigquery.updates import UpdateRecordExpander, UpdatesTable
-from lsst.dax.ppdb.tests._bigquery import have_valid_google_credentials
+from lsst.dax.ppdb.tests import (
+    create_datasets,
+    delete_datasets,
+    have_valid_google_credentials,
+    make_bigquery_config,
+)
 from lsst.dax.ppdb.tests._updates import _create_test_update_records
 
 
@@ -38,31 +43,26 @@ class TestUpdatesTable(unittest.TestCase):
         # Create BigQuery client.
         self.client = bigquery.Client()
 
-        # Create unique dataset name for this test run.
-        self.dataset_id = f"test_updates_{uuid.uuid4().hex[:8]}"
-        self.project_id = self.client.project
-        self.table_name = "updates"
-        self.table_fqn = f"{self.project_id}.{self.dataset_id}.{self.table_name}"
+        # Create PPDB BigQuery config for test.
+        self.config = make_bigquery_config(test_name="test_updates_table")
 
-        # Create the test dataset.
-        dataset = bigquery.Dataset(f"{self.project_id}.{self.dataset_id}")
+        # Create the BigQuery dataset for the tests.
+        create_datasets(self.config, [DatasetType.STAGING])
 
-        # Set a short expiration on the dataset for cleanup safety (1 hour).
-        dataset.default_table_expiration_ms = 3600000
+        # Set the FQN of the updates table.
+        self.table_fqn = self.config.fqn_for(DatasetType.STAGING, "updates")
 
-        self.dataset = self.client.create_dataset(dataset)
-
-        # Create UpdatesTable instance.
-        self.updates_table = UpdatesTable(self.client, self.project_id, self.dataset_id)
+        # Create the UpdatesTable instance.
+        self.updates_table = UpdatesTable(self.client, self.config.project_id, self.config.datasets.staging)
 
     def tearDown(self) -> None:
         """Clean up test fixtures."""
         # Always clean up the test dataset, whether test passed or failed.
         try:
-            self.client.delete_dataset(self.dataset_id, delete_contents=True, not_found_ok=True)
+            delete_datasets(self.config, [DatasetType.STAGING])
         except Exception:
-            # If deletion fails, at least the expiration will clean it up.
-            pass
+            self.fail("Failed to delete test datasets")
+            raise
 
     def test_table_fqn_property(self) -> None:
         """Test the table_fqn property."""
@@ -73,8 +73,8 @@ class TestUpdatesTable(unittest.TestCase):
         table = self.updates_table.create()
 
         # Verify table was created successfully.
-        self.assertEqual(table.table_id, self.table_name)
-        self.assertEqual(table.dataset_id, self.dataset_id)
+        self.assertEqual(table.table_id, "updates")
+        self.assertEqual(table.dataset_id, self.config.datasets.staging)
 
         # Verify schema is correct.
         expected_fields = {


### PR DESCRIPTION
This updates the BigQuery modules to use multiple datasets instead of a single one. The changes here and to the cloud functions were tested successfully in the GCP development environment (replication -> staging -> promotion).

**Changes**

- The `dataset_id` field, deprecated by [DM-49220](https://rubinobs.atlassian.net/browse/DM-49220),  was removed from the `PpdbBigQueryConfig` class and everywhere else it was used.
  - This field was also removed as an option from the command line.
- Replication and data pipeline classes (`ppdb_bigquery`, `chunk_uploader`, `chunk_promoter`, the `updates` package, etc.) were updated to use multiple datasets, primarily splitting relevant operations between the staging and internal datasets.
- Tests were updated to support multiple datasets.
- Tests were cleaned up to make better use of test utility functions for resource creation (buckets & datasets).
- Test cleanup was overhauled.
  - Tests now include cleanup methods via `addCleanup()` for deleting buckets and/or dropping datasets which were created.
- Additional assertions were added to `tests/test_updates_manager.py` for validating that updates were applied properly.
- The `table_refs` module was rewritten to incorporate support for multiple datasets.

There are additionally a few changes in this PR which should have been made on https://github.com/lsst/dax_ppdb/pull/46. Notably, the `find_chunk_by_id()` method was added to the `PpdbBigQuery` interface and the `update_chunks()` function now returns the number of updated records. The strings representing the names of updatable fields on chunks were replaced with an enum.

[DM-49220]: https://rubinobs.atlassian.net/browse/DM-49220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ