### PR TITLE
DM-55363: Use a separate dataset for promotion tables

### DIFF
--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -73,8 +73,6 @@ class ChunkPromoter:
         ApdbTables.DiaForcedSource.value,
     )
 
-    _PROMOTED_TMP_SUFFIX = "_promoted_tmp"
-
     def __init__(
         self,
         ppdb: PpdbBigQuery,
@@ -116,13 +114,6 @@ class ChunkPromoter:
         """Table names to promote (`tuple` [`str`], read-only)."""
         return self._table_names
 
-    @classmethod
-    def _promoted_tmp_name(cls, table_name: str) -> str:
-        """Return the promoted temporary table name for a given base table
-        name.
-        """
-        return f"{table_name}{cls._PROMOTED_TMP_SUFFIX}"
-
     def promote_chunks(self, chunks: list[PpdbReplicaChunkExtended]) -> None:
         """Promote APDB replica chunks into production by executing a series of
         steps in BigQuery.
@@ -153,7 +144,7 @@ class ChunkPromoter:
         # Execute the promotion steps in order.
         try:
             # Copy prod tables to temp tables and insert staged data.
-            self._copy_to_promoted_tmp()
+            self._copy_staging_to_promotion()
 
             # Fill in validityEndMjdTai for DiaObjects in the temp table.
             self._fill_diaobject_validity_end()
@@ -162,7 +153,7 @@ class ChunkPromoter:
             self._apply_record_updates()
 
             # Promote the temp tables to prod using atomic table swaps.
-            self._promote_tmp_to_prod()
+            self._copy_promotion_to_internal()
 
             # Delete the staged chunks from the staging tables.
             self._delete_staged_chunks()
@@ -181,8 +172,8 @@ class ChunkPromoter:
 
         logging.info("Completed promotion of %d chunk(s)", len(chunks))
 
-    def _copy_to_promoted_tmp(self) -> None:
-        """Build temporary tables by cloning the current prod tables and
+    def _copy_staging_to_promotion(self) -> None:
+        """Build promotion tables by cloning the current internal tables and
         inserting staged rows for the promotable chunks.
         """
         job_cfg = bigquery.QueryJobConfig(
@@ -195,14 +186,17 @@ class ChunkPromoter:
             # Build fully qualified table names which will be used in the
             # queries.
             staging_table_fqn = self.table_refs.staging(table_name)
+            promotion_table_fqn = self.table_refs.promotion(table_name)
             internal_table_fqn = self.table_refs.internal(table_name)
-            tmp_table_fqn = self.table_refs.internal(self._promoted_tmp_name(table_name))
 
-            # Drop existing promoted tmp table, if it exists.
-            self._runner.run_job("drop_tmp", f"DROP TABLE IF EXISTS `{tmp_table_fqn}`")
+            # Drop existing promotion table, if it exists.
+            self._runner.run_job("drop_promotion_if_exists", f"DROP TABLE IF EXISTS `{promotion_table_fqn}`")
 
-            # Clone prod table structure and data (zero-copy).
-            self._runner.run_job("clone_prod", f"CREATE TABLE `{tmp_table_fqn}` CLONE `{internal_table_fqn}`")
+            # Clone the current internal table structure and data (zero-copy).
+            self._runner.run_job(
+                "clone_internal_to_promotion",
+                f"CREATE OR REPLACE TABLE `{promotion_table_fqn}` CLONE `{internal_table_fqn}`",
+            )
 
             # Build target column list for SQL statement from the internal
             # table's schema. This will include the geo_point column.
@@ -217,23 +211,20 @@ class ChunkPromoter:
                 for column_name in target_names
             )
 
-            # Insert staged rows into the promoted tmp table. If the staging
+            # Insert staged rows into the promotion table. If the staging
             # and internal schemas do not match, this will fail.
             sql = f"""
-            INSERT INTO `{tmp_table_fqn}` ({target_list_sql})
+            INSERT INTO `{promotion_table_fqn}` ({target_list_sql})
             SELECT {source_list_sql}
             FROM `{staging_table_fqn}` AS s
             WHERE s.apdb_replica_chunk IN UNNEST(@ids)
             """
-            logging.debug("SQL for inserting staged rows into %s: %s", tmp_table_fqn, sql)
-            self._runner.run_job("insert_staged_to_tmp", sql, job_config=job_cfg)
+            logging.debug("SQL for inserting staged rows into %s: %s", promotion_table_fqn, sql)
+            self._runner.run_job("insert_staged_to_promotion", sql, job_config=job_cfg)
 
     def _apply_record_updates(self) -> None:
-        """Apply record updates to the promoted temporary tables."""
-        updates_manager = UpdatesManager(
-            self._ppdb.config,
-            table_name_format="{}" + self._PROMOTED_TMP_SUFFIX,
-        )
+        """Apply record updates to the promotion tables."""
+        updates_manager = UpdatesManager(config=self._ppdb.config)
 
         # Apply the updates for the chunks. The manager will skip the process
         # entirely if there are no updates, so we don't need to check that
@@ -246,8 +237,7 @@ class ChunkPromoter:
         """
         job_name = "fill_diaobject_validity_end"
 
-        target_table = self._promoted_tmp_name(ApdbTables.DiaObject.value)
-        target_table_fqn = self.table_refs.internal(target_table)
+        target_table_fqn = self.table_refs.promotion(ApdbTables.DiaObject.value)
 
         staging_table = ApdbTables.DiaObject.value
         staging_table_fqn = self.table_refs.staging(staging_table)
@@ -273,29 +263,30 @@ class ChunkPromoter:
         else:
             logging.warning("Finished job '%s' but DML stats are not available", job_name)
 
-    def _promote_tmp_to_prod(self) -> None:
-        """Swap each prod table with its corresponding *_promoted_tmp by
-        replacing prod contents in a single atomic copy job. This preserves
+    def _copy_promotion_to_internal(self) -> None:
+        """Swap each internal table with its corresponding promotion table by
+        replacing internal contents in a single atomic copy job. This preserves
         schema, partitioning, and clustering with zero-copy when in the same
         dataset.
         """
         for table_name in self.table_names:
-            tmp_ref = self.table_refs.internal(self._promoted_tmp_name(table_name))
-            prod_ref = self.table_refs.internal(table_name)
+            promotion_ref = self.table_refs.promotion(table_name)
+            internal_ref = self.table_refs.internal(table_name)
 
-            # Ensure tmp exists.
+            # Ensure promotion table exists.
             try:
-                self._bq_client.get_table(tmp_ref)
+                self._bq_client.get_table(promotion_ref)
             except NotFound as e:
-                raise RuntimeError(f"Missing tmp table for promotion: {tmp_ref}") from e
+                raise RuntimeError(f"Missing promotion table: {promotion_ref}") from e
 
-            # Perform an atomic, zero-copy replacement of prod with temp.
+            # Perform an atomic, zero-copy replacement of internal with its
+            # corresponding promotion table.
             copy_cfg = bigquery.CopyJobConfig(write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE)
             job = self._bq_client.copy_table(
-                tmp_ref, prod_ref, job_config=copy_cfg, location=self._runner.location
+                promotion_ref, internal_ref, job_config=copy_cfg, location=self._runner.location
             )
             job.result()
-            QueryRunner.log_job(job, "promote_tmp_to_prod")
+            QueryRunner.log_job(job, "copy_promotion_to_internal")
 
     def _delete_staged_chunks(self) -> None:
         """Delete only rows for the promoted replica chunk IDs from each
@@ -327,11 +318,11 @@ class ChunkPromoter:
 
     def _cleanup(self) -> None:
         """Cleanup state after executing the promotion."""
-        # Delete the tmp tables.
+        # Delete the promotion tables.
         for table_name in self.table_names:
-            tmp_ref = self.table_refs.internal(self._promoted_tmp_name(table_name))
-            self._bq_client.delete_table(tmp_ref, not_found_ok=True)
-            logging.debug("Dropped %s (if it existed)", tmp_ref)
+            promotion_ref = self.table_refs.promotion(table_name)
+            self._bq_client.delete_table(promotion_ref, not_found_ok=True)
+            logging.debug("Dropped %s (if it existed)", promotion_ref)
 
         # Reset the chunk list.
         self._promotable_chunks = []

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery_config.py
@@ -41,6 +41,7 @@ class DatasetType(StrEnum):
 
     STAGING = "staging"
     INTERNAL = "internal"
+    PROMOTION = "promotion"
     PUBLIC = "public"
 
 
@@ -55,6 +56,10 @@ class Datasets(BaseModel):
     """Name of the internal dataset containing the fully replicated and
     promoted data."""
 
+    promotion: str = f"{_PPDB_PREFIX}_promotion"
+    """Name of the promotion dataset used as a workspace for building new
+    internal tables."""
+
     public: str = f"{_PPDB_PREFIX}_public"
     """Name of the public dataset which is presented through the TAP
     interface."""
@@ -64,6 +69,8 @@ class Datasets(BaseModel):
         match dataset_type:
             case DatasetType.INTERNAL:
                 return self.internal
+            case DatasetType.PROMOTION:
+                return self.promotion
             case DatasetType.PUBLIC:
                 return self.public
             case DatasetType.STAGING:

--- a/python/lsst/dax/ppdb/bigquery/schema/dataset_builder.py
+++ b/python/lsst/dax/ppdb/bigquery/schema/dataset_builder.py
@@ -253,6 +253,17 @@ class InternalDatasetBuilder(BaseDatasetBuilder):
         ]
 
 
+class PromotionDatasetBuilder(BaseDatasetBuilder):
+    """Builder for the promotion dataset type.
+
+    This dataset type is used as a workspace for the promotion process. It does
+    not currently define any tables or views but uses copies of tables from
+    other datasets.
+    """
+
+    dataset_type = DatasetType.PROMOTION
+
+
 class PublicDatasetBuilder(BaseDatasetBuilder):
     """Builder for the public dataset type."""
 
@@ -351,6 +362,7 @@ class DatasetBuildManager:
         {
             StagingDatasetBuilder.dataset_type: StagingDatasetBuilder,
             InternalDatasetBuilder.dataset_type: InternalDatasetBuilder,
+            PromotionDatasetBuilder.dataset_type: PromotionDatasetBuilder,
             PublicDatasetBuilder.dataset_type: PublicDatasetBuilder,
         }
     )

--- a/python/lsst/dax/ppdb/bigquery/table_refs.py
+++ b/python/lsst/dax/ppdb/bigquery/table_refs.py
@@ -53,6 +53,21 @@ class TableRefs:
         """
         return self._config.fqn_for(DatasetType.STAGING, table_name)
 
+    def promotion(self, table_name: str) -> str:
+        """Return the fully qualified promotion table reference.
+
+        Parameters
+        ----------
+        table_name
+            Name of the table.
+
+        Returns
+        -------
+        `str`
+            Fully qualified promotion table reference.
+        """
+        return self._config.fqn_for(DatasetType.PROMOTION, table_name)
+
     def internal(self, table_name: str) -> str:
         """Return the fully qualified internal table reference.
 

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -42,12 +42,6 @@ from .updates_merger import (
 )
 from .updates_table import UpdatesTable
 
-_DEFAULT_MERGERS: tuple[UpdatesMerger, ...] = (
-    DiaObjectUpdatesMerger(),
-    DiaSourceUpdatesMerger(),
-    DiaForcedSourceUpdatesMerger(),
-)
-
 _LOG = logging.getLogger(__name__)
 
 
@@ -65,6 +59,10 @@ class UpdatesManager:
     ----------
     config
         Configuration for the PPDB BigQuery interface.
+    target_dataset_fqn
+        Fully qualified name of the dataset containing the target tables to
+        merge updates into, or `None` to use the promotion dataset from the
+        configuration.
     mergers
         Merger instances to apply, or `None` to use the default set of mergers
         for the standard target tables.
@@ -73,25 +71,30 @@ class UpdatesManager:
     def __init__(
         self,
         config: PpdbBigQueryConfig,
+        target_dataset_fqn: str | None = None,
         mergers: Sequence[UpdatesMerger] | None = None,
     ) -> None:
         # Get some necessary setup information from the config.
         project_id = config.project_id
         bucket_name = config.bucket_name
 
-        # Merger instances for handling each target table. Fall back to the
-        # default set of mergers if none were provided.
-        if mergers:
+        # Set the merger instances for handling each target table, falling back
+        # to a default set of mergers if none were provided.
+        if mergers is not None:
             self._mergers = tuple(mergers)
         else:
-            self._mergers = _DEFAULT_MERGERS
+            self._mergers = (
+                DiaObjectUpdatesMerger(),
+                DiaSourceUpdatesMerger(),
+                DiaForcedSourceUpdatesMerger(),
+            )
 
         # Setup the updates table interface.
         self._bq_client = bigquery.Client()
         self._updates_table = UpdatesTable(
             self._bq_client,
             project_id,
-            config.datasets.staging,
+            config.datasets.promotion,
         )
 
         # Setup the GCS client and bucket.
@@ -99,7 +102,11 @@ class UpdatesManager:
         self._bucket = self._gcs_client.bucket(bucket_name)
 
         # Set the target dataset FQN for the mergers to use.
-        self._target_dataset_fqn = config.fqn_for(DatasetType.INTERNAL)
+        if target_dataset_fqn is None:
+            # By default, use the promotion dataset as the merge target.
+            self._target_dataset_fqn = config.fqn_for(DatasetType.PROMOTION)
+        else:
+            self._target_dataset_fqn = target_dataset_fqn
 
     def apply_updates(self, replica_chunks: Sequence[PpdbReplicaChunkExtended]) -> None:
         """Apply update records from replica chunk data to target tables in
@@ -152,6 +159,8 @@ class UpdatesManager:
         except Exception as e:
             raise UpdatesManagerError("Failed to merge updates into target tables") from e
 
+    # TODO: This method will be removed by DM-55338, as populating the updates
+    # table will be handled by the staging process.
     def _build_updates_table(self, chunks: Sequence[PpdbReplicaChunkExtended]) -> None:
         """Build the updates table by expanding the update records from the
         replica chunks and inserting them.

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_manager.py
@@ -42,10 +42,10 @@ from .updates_merger import (
 )
 from .updates_table import UpdatesTable
 
-_DEFAULT_MERGER_CLASSES: tuple[type[UpdatesMerger], ...] = (
-    DiaObjectUpdatesMerger,
-    DiaSourceUpdatesMerger,
-    DiaForcedSourceUpdatesMerger,
+_DEFAULT_MERGERS: tuple[UpdatesMerger, ...] = (
+    DiaObjectUpdatesMerger(),
+    DiaSourceUpdatesMerger(),
+    DiaForcedSourceUpdatesMerger(),
 )
 
 _LOG = logging.getLogger(__name__)
@@ -65,21 +65,26 @@ class UpdatesManager:
     ----------
     config
         Configuration for the PPDB BigQuery interface.
-    table_name_format
-        Optional format string for the target table names used by the mergers.
+    mergers
+        Merger instances to apply, or `None` to use the default set of mergers
+        for the standard target tables.
     """
 
     def __init__(
         self,
         config: PpdbBigQueryConfig,
-        table_name_format: str | None = None,
+        mergers: Sequence[UpdatesMerger] | None = None,
     ) -> None:
         # Get some necessary setup information from the config.
         project_id = config.project_id
         bucket_name = config.bucket_name
 
-        # Merger instances for handling each target table.
-        self._mergers = tuple(cls(table_name_format=table_name_format) for cls in _DEFAULT_MERGER_CLASSES)
+        # Merger instances for handling each target table. Fall back to the
+        # default set of mergers if none were provided.
+        if mergers:
+            self._mergers = tuple(mergers)
+        else:
+            self._mergers = _DEFAULT_MERGERS
 
         # Setup the updates table interface.
         self._bq_client = bigquery.Client()

--- a/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
+++ b/python/lsst/dax/ppdb/bigquery/updates/updates_merger.py
@@ -36,15 +36,6 @@ from ..sql_resource import SqlResource
 class UpdatesMerger:
     """Abstract base class for merging expanded update records into target
     tables in BigQuery.
-
-    Parameters
-    ----------
-    table_name_format
-        Optional format string for the target table name. The
-        class-level ``TABLE_NAME`` will be substituted into ``{}``
-        (e.g., ``"_{}_promoted_tmp"`` produces
-        ``"_DiaObject_promoted_tmp"``).
-        If not provided, ``TABLE_NAME`` is used as-is.
     """
 
     TABLE_NAME: str
@@ -56,17 +47,6 @@ class UpdatesMerger:
     """Base name of the SQL file (without .sql extension) containing the MERGE
     statement for this merger. The SQL file must be located in the
     ``lsst.dax.ppdb.config.sql`` package."""
-
-    def __init__(self, table_name_format: str | None = None) -> None:
-        if table_name_format:
-            self._target_table_name = table_name_format.format(self.TABLE_NAME)
-        else:
-            self._target_table_name = self.TABLE_NAME
-
-    @property
-    def target_table_name(self) -> str:
-        """Name of the target table to which this merger applies."""
-        return self._target_table_name
 
     def merge(
         self, *, client: bigquery.Client, updates_table_fqn: str, target_dataset_fqn: str
@@ -94,7 +74,7 @@ class UpdatesMerger:
             format_args={
                 "updates_table": updates_table_fqn,
                 "target_dataset": target_dataset_fqn,
-                "target_table": self.target_table_name,
+                "target_table": self.TABLE_NAME,
             },
         ).sql
         job = client.query(sql)

--- a/python/lsst/dax/ppdb/resources/config/sql/fill_diaobject_validity_end.sql
+++ b/python/lsst/dax/ppdb/resources/config/sql/fill_diaobject_validity_end.sql
@@ -1,5 +1,5 @@
--- This SQL script fills in null validityEndMjTai values for DiaObject rows
--- in the target table, which will typically be the "promoted_tmp" version
+-- This SQL script fills in null validityEndMjdTai values for DiaObject rows
+-- in the target table, which is the DiaObject table in the promotion dataset
 -- containing the existing data plus updates from staging. It uses a MERGE
 -- statement to update the target table in place.
 MERGE `{target_table}` AS T

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -111,6 +111,7 @@ def make_bigquery_config(
         datasets=Datasets(
             staging=f"{test_name}_staging_{unique_id}",
             internal=f"{test_name}_internal_{unique_id}",
+            promotion=f"{test_name}_promotion_{unique_id}",
             public=f"{test_name}_public_{unique_id}",
         ),
         sql=PpdbSqlBaseConfig(

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -296,10 +296,10 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
                 rows = self._query_table(staging_table_fqn)
                 self.assertEqual(len(rows), 0, f"{staging_table_fqn} should be empty")
 
-        # Verify tmp tables were cleaned up.
+        # Verify promotion tables were cleaned up.
         for table_name in self.TABLE_NAMES:
-            tmp_ref = self.config.fqn_for(DatasetType.INTERNAL, f"{table_name}_promoted_tmp")
-            self.assertFalse(self._table_exists(tmp_ref), f"{tmp_ref} should not exist")
+            promotion_ref = self.config.fqn_for(DatasetType.PROMOTION, table_name)
+            self.assertFalse(self._table_exists(promotion_ref), f"{promotion_ref} should not exist")
 
         # Verify all chunks are marked PROMOTED.
         for chunk in self.ppdb.query_chunks():
@@ -327,7 +327,7 @@ class FillValidityEndTestCase(unittest.TestCase):
     scenarios.
     """
 
-    dataset_types = (DatasetType.INTERNAL, DatasetType.STAGING)
+    dataset_types = (DatasetType.PROMOTION, DatasetType.STAGING)
 
     def setUp(self):
         # Create the PPDB BigQuery config.
@@ -340,15 +340,15 @@ class FillValidityEndTestCase(unittest.TestCase):
         self.addCleanup(drop_datasets, self.config, self.dataset_types)
 
         # Build table FQNs for the test tables.
-        self.internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, "DiaObject_promoted_tmp")
+        self.target_table_fqn = self.config.fqn_for(DatasetType.PROMOTION, "DiaObject")
         self.staging_table_fqn = self.config.fqn_for(DatasetType.STAGING, "DiaObject")
 
         self.bq_client = bigquery.Client()
 
-        # Create target table (promoted_tmp).
+        # Create target table (promotion DiaObject).
         self.bq_client.query(
             f"""
-            CREATE TABLE `{self.internal_table_fqn}` (
+            CREATE TABLE `{self.target_table_fqn}` (
                 diaObjectId INT64,
                 validityStartMjdTai FLOAT64,
                 validityEndMjdTai FLOAT64
@@ -369,7 +369,7 @@ class FillValidityEndTestCase(unittest.TestCase):
         ).result()
 
     def _insert_target_rows(self, rows: list[tuple]) -> None:
-        """Insert rows into the internal table.
+        """Insert rows into the target table.
 
         Each row is (diaObjectId, validityStartMjdTai, validityEndMjdTai).
         """
@@ -377,7 +377,7 @@ class FillValidityEndTestCase(unittest.TestCase):
             return
         values = ", ".join(f"({r[0]}, {r[1]}, {'NULL' if r[2] is None else r[2]})" for r in rows)
         self.bq_client.query(
-            f"INSERT INTO `{self.internal_table_fqn}` (diaObjectId, validityStartMjdTai, validityEndMjdTai) "
+            f"INSERT INTO `{self.target_table_fqn}` (diaObjectId, validityStartMjdTai, validityEndMjdTai) "
             f"VALUES {values}"
         ).result()
 
@@ -401,7 +401,7 @@ class FillValidityEndTestCase(unittest.TestCase):
         sql = SqlResource(
             "fill_diaobject_validity_end",
             format_args={
-                "target_table": self.internal_table_fqn,
+                "target_table": self.target_table_fqn,
                 "staging_table": self.staging_table_fqn,
             },
         ).sql
@@ -413,7 +413,7 @@ class FillValidityEndTestCase(unittest.TestCase):
         """
         rows = self.bq_client.query(
             f"SELECT diaObjectId, validityStartMjdTai, validityEndMjdTai "
-            f"FROM `{self.internal_table_fqn}` ORDER BY diaObjectId, validityStartMjdTai"
+            f"FROM `{self.target_table_fqn}` ORDER BY diaObjectId, validityStartMjdTai"
         ).result()
         return [dict(row) for row in rows]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,9 +28,7 @@ import unittest
 import yaml
 from google.cloud import bigquery
 
-from lsst.dax.ppdb.bigquery.ppdb_bigquery_config import (
-    DatasetType,
-)
+from lsst.dax.ppdb.bigquery.ppdb_bigquery_config import DatasetType
 from lsst.dax.ppdb.cli import ppdb_cli
 from lsst.dax.ppdb.tests._bigquery import (
     drop_datasets,
@@ -79,7 +77,13 @@ class CreateDatasetsTestCase(unittest.TestCase):
             dataset_fqn = self.config.fqn_for(dataset_type)
             self.client.get_dataset(dataset_fqn)
             tables = list(self.client.list_tables(dataset_fqn))
-            self.assertEqual(len(tables), 3)
+            if dataset_type != DatasetType.PROMOTION:
+                # The staging, internal, and public datasets should each have
+                # three tables created by default.
+                self.assertEqual(len(tables), 3)
+            else:
+                # Promotion dataset should have no tables created by default.
+                self.assertEqual(len(tables), 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset_builder.py
+++ b/tests/test_dataset_builder.py
@@ -76,6 +76,7 @@ class DatasetBuilderTestMixin:
             project_id="test-project",
             datasets=Datasets(
                 internal="test_dataset_builder_internal",
+                promotion="test_dataset_builder_promotion",
                 public="test_dataset_builder_public",
                 staging="test_dataset_builder_staging",
             ),
@@ -685,6 +686,7 @@ class DatasetBuilderBigQueryTestCase(unittest.TestCase):
         suffix = uuid.uuid4().hex[:8]
         self.datasets = Datasets(
             internal=f"test_dataset_builder_internal_{suffix}",
+            promotion=f"test_dataset_builder_promotion_{suffix}",
             public=f"test_dataset_builder_public_{suffix}",
             staging=f"test_dataset_builder_staging_{suffix}",
         )

--- a/tests/test_updates_manager.py
+++ b/tests/test_updates_manager.py
@@ -58,7 +58,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
     related classes including the ChunkUploader.
     """
 
-    dataset_types = (DatasetType.INTERNAL, DatasetType.STAGING)
+    dataset_types = (DatasetType.PROMOTION, DatasetType.STAGING)
 
     def setUp(self):
         super().setUp()
@@ -73,7 +73,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         create_datasets(self.config, self.dataset_types)
 
         # Create the test tables in BigQuery.
-        self._create_test_tables(self.config, DatasetType.INTERNAL)
+        self._create_test_tables(self.config, DatasetType.PROMOTION)
 
         # Create the test GCS bucket.
         create_bucket(self.config)
@@ -231,7 +231,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         client = bigquery.Client()
 
         # Verify DiaSource updates.
-        dia_source_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaSource")
+        dia_source_fqn = self.ppdb.config.fqn_for(DatasetType.PROMOTION, "DiaSource")
         rows = client.query(
             f"""
             SELECT
@@ -276,7 +276,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         self.assertIsNone(dia_sources[100004]["timeWithdrawnMjdTai"])
 
         # Verify DiaForcedSource updates.
-        dia_forced_source_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaForcedSource")
+        dia_forced_source_fqn = self.ppdb.config.fqn_for(DatasetType.PROMOTION, "DiaForcedSource")
         rows = client.query(
             f"""
             SELECT
@@ -313,7 +313,7 @@ class UpdatesManagerTestCase(PostgresMixin, unittest.TestCase):
         )
 
         # Verify DiaObject updates.
-        dia_object_fqn = self.ppdb.config.fqn_for(DatasetType.INTERNAL, "DiaObject")
+        dia_object_fqn = self.ppdb.config.fqn_for(DatasetType.PROMOTION, "DiaObject")
         rows = client.query(
             f"""
             SELECT


### PR DESCRIPTION
This changes the modules related to promotion and application of record updates to use a separate dataset as a workspace for building the temporary tables which contain staging data appended to the current internal (production) tables.

Some minor changes to the classes which apply updates were also made to simplify them now that the natural table names can be used (`DiaObject`, etc.).

After this update, the datasets are now organized like:

- `staging`: staged chunk data from replication written by the Dataflow jobs
- `promotion`: workspace for building new production tables and applying record updates
- `internal`: production tables built by promotion process
- `public`: public views on internal tables and table copies/subsets (e.g., for the `DiaObject` "latest" table) which are exposed to the PPDB TAP service