### PR TITLE
DM-55458: Enable Google Cloud environment in GitHub CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,9 +71,17 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest -r a -v -n auto --cov=lsst.dax.ppdb \
-            --cov-report=xml --cov-report=term --cov-branch \
-            --junitxml=junit.xml -o junit_family=legacy
+          pytest \
+            -v \
+            --log-cli-level WARNING \
+            -r a \
+            -n auto \
+            --cov=lsst.dax.ppdb \
+            --cov-report=xml \
+            --cov-report=term \
+            --cov-branch \
+            --junitxml=junit.xml \
+            -o junit_family=legacy
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,11 @@ jobs:
           # Need to clone everything for the git tags.
           fetch-depth: 0
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
       - uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}

--- a/python/lsst/dax/ppdb/tests/_bigquery.py
+++ b/python/lsst/dax/ppdb/tests/_bigquery.py
@@ -350,7 +350,7 @@ def have_valid_google_credentials() -> bool:
         Raised for other transport or configuration failures.
     """
     try:
-        credentials, _ = google.auth.default()
+        credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
         credentials.refresh(Request())
     except (DefaultCredentialsError, RefreshError):
         return False


### PR DESCRIPTION
This enables the Google Cloud environment for running tests in GitHub CI.

The credentials used are for a dedicated SA on the `ppdb-dev` project with minimal permissions.