### PR TITLE
DM-54475: Add creation of DiaObject latest table to promotion process

### DIFF
--- a/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
+++ b/python/lsst/dax/ppdb/bigquery/chunk_promoter.py
@@ -155,6 +155,10 @@ class ChunkPromoter:
             # Promote the temp tables to prod using atomic table swaps.
             self._copy_promotion_to_internal()
 
+            # Create the copy of the DiaObject table in the public dataset
+            # containing only the most recent versions.
+            self._create_diaobject_latest()
+
             # Delete the staged chunks from the staging tables.
             self._delete_staged_chunks()
 
@@ -287,6 +291,26 @@ class ChunkPromoter:
             )
             job.result()
             QueryRunner.log_job(job, "copy_promotion_to_internal")
+
+    def _create_diaobject_latest(self) -> None:
+        """Create the copy of the DiaObject table in the public dataset
+        containing only the most recent versions.
+        """
+        internal_table_fqn = self.table_refs.internal(ApdbTables.DiaObject.value)
+        public_table_fqn = self.table_refs.public(ApdbTables.DiaObject.value)
+
+        job_name = "create_diaobject_latest"
+
+        job = self._runner.run_job(
+            job_name,
+            f"""CREATE OR REPLACE TABLE `{public_table_fqn}`
+            CLUSTER BY geo_point AS
+            SELECT * EXCEPT (validityEndMjdTai)
+            FROM `{internal_table_fqn}`
+            WHERE validityEndMjdTai IS NULL""",
+        )
+        job.result()
+        QueryRunner.log_job(job, job_name)
 
     def _delete_staged_chunks(self) -> None:
         """Delete only rows for the promoted replica chunk IDs from each

--- a/tests/test_chunk_promoter.py
+++ b/tests/test_chunk_promoter.py
@@ -164,6 +164,10 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
             if parquet_path.exists():
                 self._load_parquet_to_table(parquet_path, internal_table_fqn)
                 self.bq_client.query(f"TRUNCATE TABLE `{internal_table_fqn}`").result()
+                # Add the expected geo_point column to the internal table.
+                self.bq_client.query(
+                    f"ALTER TABLE `{internal_table_fqn}` ADD COLUMN IF NOT EXISTS geo_point GEOGRAPHY"
+                ).result()
 
     def _load_chunk_to_staging(self, chunk: PpdbReplicaChunkExtended) -> None:
         """Load a chunk's parquet files into staging tables and add the
@@ -307,6 +311,35 @@ class ChunkPromoterTestCase(PostgresMixin, unittest.TestCase):
 
         # Verify promoted data matches staging data with updates applied.
         self._verify_promoted_data(staging_rows, expanded_updates)
+
+        # Verify the public DiaObject table contains only the latest version of
+        # each DiaObject with the validityEndMjdTai column dropped.
+        public_table_fqn = self.config.fqn_for(DatasetType.PUBLIC, ApdbTables.DiaObject.value)
+        internal_table_fqn = self.config.fqn_for(DatasetType.INTERNAL, ApdbTables.DiaObject.value)
+        self.assertTrue(self._table_exists(public_table_fqn), f"{public_table_fqn} should exist")
+        public_field_names = [field.name for field in self.bq_client.get_table(public_table_fqn).schema]
+        self.assertNotIn("validityEndMjdTai", public_field_names)
+        latest_rows = [
+            {name: value for name, value in row.items() if name != "validityEndMjdTai"}
+            for row in self._query_table(internal_table_fqn)
+            if row["validityEndMjdTai"] is None
+        ]
+        public_rows = self._query_table(public_table_fqn)
+        self.assertEqual(len(public_rows), len(latest_rows))
+        self.assertEqual(
+            len({row["diaObjectId"] for row in public_rows}),
+            len(public_rows),
+            "Expected exactly one latest row per diaObjectId in public DiaObject",
+        )
+        self.assertEqual(
+            {row["diaObjectId"] for row in public_rows},
+            {row["diaObjectId"] for row in latest_rows},
+        )
+
+        expected_public = pd.DataFrame(latest_rows).sort_values("diaObjectId").reset_index(drop=True)
+        actual_public = pd.DataFrame(public_rows).sort_values("diaObjectId").reset_index(drop=True)
+        actual_public = actual_public[expected_public.columns]
+        pd.testing.assert_frame_equal(actual_public, expected_public)
 
         # Verify no promotable chunks remain after promotion.
         self.assertEqual(self.ppdb.get_promotable_chunks(), [])


### PR DESCRIPTION
This adds creation of the `DiaObject` table in the public dataset containing only the most recent versions. 

This is implemented as an atomic `CREATE OR REPLACE TABLE` operation during the promotion process which filters on records from the internal record set which have a `validityEndMjdTai` value of `NULL` (indicating an open validity interval). 

A table copy was used instead of a regular view, which would be inefficient, and a materialized view would be awkward to manage since the table swaps during promotion would invalidate it every time.