### PR TITLE
DM-55588: Updates for switch to Rubin-managed Google Cloud project

### DIFF
--- a/docker/Dockerfile.replication
+++ b/docker/Dockerfile.replication
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       build-essential \
+      libpq-dev \
       python3-dev \
       pkg-config \
       git \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "pytest >= 3.2",
     "pytest-openfiles >= 0.5.0"
 ]
+postgres = ["psycopg2"]
 
 [tool.setuptools.packages.find]
 where = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ keywords = ["lsst"]
 dependencies = [
     "astropy",
     "google-cloud-bigquery",
+    "cloud-sql-python-connector[pg8000]",
     "pyarrow",
     "pydantic >=2,<3",
     "pyyaml >= 5.1",

--- a/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
+++ b/python/lsst/dax/ppdb/bigquery/ppdb_bigquery.py
@@ -35,6 +35,8 @@ import astropy.time
 import felis
 import sqlalchemy
 from google.cloud import secretmanager
+from google.cloud.sql.connector import Connector
+from sqlalchemy.engine.interfaces import DBAPIConnection
 
 from lsst.dax.apdb import (
     ApdbMetadata,
@@ -109,6 +111,12 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
     ----------
     config
         Configuration object with BigQuery and SQL database parameters.
+
+    Notes
+    -----
+    Whether the SQLAlchemy engine uses the Cloud SQL Python Connector is
+    controlled by the ``CLOUDSQL_ENABLED`` environment variable; see
+    `is_cloudsql_enabled` and `make_engine`.
     """
 
     # ----------------------------------------------------------------------
@@ -122,8 +130,14 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
 
         # Delegate SQL initialisation (schema load, engine, metadata, version
         # checks) to the base class, passing the optional password provider.
+        # Whether the Cloud SQL Connector is used is determined from the
+        # environment (see `is_cloudsql_enabled`) inside `make_engine`.
         password_provider = self._make_password_provider(config.project_id)
-        PpdbSqlBase.__init__(self, config.sql, password_provider=password_provider)
+        PpdbSqlBase.__init__(
+            self,
+            config.sql,
+            password_provider=password_provider,
+        )
 
         self._config = config
 
@@ -157,16 +171,28 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
         -------
         `PpdbBigQuery`
             An instance of the PPDB BigQuery interface.
+
+        Raises
+        ------
+        OSError
+            Raised if ``PPDB_CONFIG_URI`` is not set in the environment.
+        ValueError
+            Raised if the configuration is not for a BigQuery PPDB.
+
+        Notes
+        -----
+        Whether the Cloud SQL Python Connector is used is controlled by the
+        ``CLOUDSQL_ENABLED`` environment variable; see `is_cloudsql_enabled`.
         """
         ppdb_config_uri = os.environ.get("PPDB_CONFIG_URI", None)
         if ppdb_config_uri:
             logging.info("PPDB_CONFIG_URI: %s", ppdb_config_uri)
         else:
             raise OSError("PPDB_CONFIG_URI is not set in the environment")
-        ppdb = Ppdb.from_uri(ppdb_config_uri)
-        if not isinstance(ppdb, PpdbBigQuery):
-            raise ValueError(f"Ppdb from environment has wrong type: {type(ppdb)}")
-        return ppdb
+        config = PpdbBigQueryConfig.from_uri(ppdb_config_uri)
+        if not isinstance(config, PpdbBigQueryConfig):
+            raise ValueError(f"Config from environment has wrong type: {type(config)}")
+        return cls(config)
 
     @classmethod
     def init_bigquery(
@@ -327,6 +353,142 @@ class PpdbBigQuery(Ppdb, PpdbSqlBase):
                 check_dataset_exists(config.project_id, dataset_name)
             except Exception as e:
                 raise ConfigValidationError(f"Failed to validate BigQuery dataset: {dataset_name}") from e
+
+    # ----------------------------------------------------------------------
+    # Engine creation
+    # ----------------------------------------------------------------------
+
+    @classmethod
+    def is_cloudsql_enabled(cls) -> bool:
+        """Return whether the Cloud SQL Python Connector is enabled.
+
+        Returns
+        -------
+        `bool`
+            `True` if the ``CLOUDSQL_ENABLED`` environment variable is set to
+            ``"true"`` (case-insensitive), `False` otherwise.
+        """
+        return os.environ.get("CLOUDSQL_ENABLED", "false").lower() == "true"
+
+    @classmethod
+    def make_engine(
+        cls,
+        config: PpdbSqlBaseConfig,
+        *,
+        password_provider: PasswordProvider | None = None,
+    ) -> sqlalchemy.engine.Engine:
+        """Make a SQLAlchemy engine, optionally using the Cloud SQL Connector.
+
+        Whether the Cloud SQL Python Connector is used is determined by the
+        ``CLOUDSQL_ENABLED`` environment variable (see `is_cloudsql_enabled`).
+        When enabled, the connection parameters are read from the environment:
+
+        - ``CLOUDSQL_INSTANCE_CONNECTION_NAME``: instance connection name in
+          the form ``project:region:instance`` (required).
+        - ``CLOUDSQL_USER``: database user or IAM principal (required).
+        - ``CLOUDSQL_DB_NAME``: database name (required).
+        - ``CLOUDSQL_DRIVERNAME``: Cloud SQL Connector database driver.
+          Defaults to ``pg8000``.
+        - ``CLOUDSQL_IP_TYPE``: IP type used to reach the instance, one of
+          ``private`` (default), ``public``, or ``psc``.
+
+        Authentication uses automatic IAM database authentication unless
+        ``password_provider`` is given, in which case password authentication
+        is used.
+
+        Parameters
+        ----------
+        config
+            Configuration object with SQL parameters.
+        password_provider
+            If provided, the password returned by
+            ``password_provider.get_password()`` is used for authentication.
+
+        Returns
+        -------
+        `sqlalchemy.engine.Engine`
+            The SQLAlchemy engine.
+        """
+        if cls.is_cloudsql_enabled():
+            return cls._make_connector_engine(password_provider=password_provider)
+        return super().make_engine(config, password_provider=password_provider)
+
+    @classmethod
+    def _make_connector_engine(
+        cls,
+        *,
+        password_provider: PasswordProvider | None = None,
+    ) -> sqlalchemy.engine.Engine:
+        """Create a SQLAlchemy engine using the Cloud SQL Python Connector.
+
+        The connection parameters are read from the environment; see
+        `make_engine` for the environment variables that are used.
+
+        Parameters
+        ----------
+        password_provider
+            If provided, its password is used for password authentication and
+            automatic IAM database authentication is disabled. If not
+            provided, automatic IAM database authentication is used.
+
+        Returns
+        -------
+        `sqlalchemy.engine.Engine`
+            The SQLAlchemy engine backed by the Cloud SQL Connector.
+
+        Raises
+        ------
+        OSError
+            Raised if a required environment variable is not set.
+
+        Notes
+        -----
+        The connector is created with a lazy refresh strategy, which is
+        recommended for serverless environments such as Cloud Run and Cloud
+        Functions where CPU may be throttled between requests. A reference to
+        the connector is retained by the returned engine's connection factory,
+        so it remains alive for the lifetime of the engine.
+        """
+        instance_connection_name = os.environ.get("CLOUDSQL_INSTANCE_CONNECTION_NAME")
+        if not instance_connection_name:
+            raise OSError("CLOUDSQL_INSTANCE_CONNECTION_NAME is not set in the environment")
+        db_user = os.environ.get("CLOUDSQL_USER")
+        if not db_user:
+            raise OSError("CLOUDSQL_USER is not set in the environment")
+        db_name = os.environ.get("CLOUDSQL_DB_NAME")
+        if not db_name:
+            raise OSError("CLOUDSQL_DB_NAME is not set in the environment")
+        driver = os.environ.get("CLOUDSQL_DRIVERNAME", "pg8000")
+
+        # The IP type may be overridden via the environment; it defaults to
+        # private, which is the recommended production configuration.
+        ip_type = os.environ.get("CLOUDSQL_IP_TYPE", "private").lower()
+        if ip_type not in ("private", "public", "psc"):
+            raise OSError(
+                f"Invalid CLOUDSQL_IP_TYPE value: {ip_type!r} (expected 'private', 'public', or 'psc')"
+            )
+        connect_kwargs: dict[str, str | bool] = {"user": db_user, "db": db_name, "ip_type": ip_type}
+        if password_provider is not None:
+            connect_kwargs["password"] = password_provider.get_password()
+            connect_kwargs["enable_iam_auth"] = False
+            _LOG.info("Using password authentication for Cloud SQL Connector")
+        else:
+            connect_kwargs["enable_iam_auth"] = True
+            _LOG.info("Using IAM authentication for Cloud SQL Connector")
+
+        # Lazy refresh is recommended for serverless environments where CPU may
+        # be throttled between requests.
+        connector = Connector(refresh_strategy="lazy")
+
+        def getconn() -> DBAPIConnection:
+            return connector.connect(instance_connection_name, driver, **connect_kwargs)
+
+        _LOG.info(
+            "Creating Cloud SQL Connector engine for %s (driver=%s)",
+            instance_connection_name,
+            driver,
+        )
+        return sqlalchemy.create_engine(f"postgresql+{driver}://", creator=getconn)
 
     # ----------------------------------------------------------------------
     # SQL schema and versioning class methods

--- a/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
+++ b/python/lsst/dax/ppdb/sql/_ppdb_sql_base.py
@@ -129,6 +129,12 @@ class PpdbSqlBase:
     ----------
     config
         Configuration object.
+    password_provider
+        Optional provider used to inject the database password into the
+        connection URL.
+    **engine_kwargs
+        Additional keyword arguments forwarded to `make_engine`. Subclasses
+        may use these to customize how the engine is created.
 
     Notes
     -----
@@ -142,12 +148,17 @@ class PpdbSqlBase:
     meta_schema_version_key = "version:schema"
     """Name of the metadata key to store Felis schema version number."""
 
-    def __init__(self, config: PpdbSqlBaseConfig, password_provider: PasswordProvider | None = None) -> None:
+    def __init__(
+        self,
+        config: PpdbSqlBaseConfig,
+        password_provider: PasswordProvider | None = None,
+        **engine_kwargs: Any,
+    ) -> None:
         self._sa_metadata, self._schema_version = self.read_schema(
             config.felis_path, config.schema_name, config.felis_schema, config.db_url
         )
 
-        self._engine = self.make_engine(config, password_provider=password_provider)
+        self._engine = self.make_engine(config, password_provider=password_provider, **engine_kwargs)
         sa_metadata = sqlalchemy.MetaData(schema=config.schema_name)
 
         meta_table = sqlalchemy.schema.Table("metadata", sa_metadata, autoload_with=self._engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@ pyarrow
 pydantic >=2,<3
 pyyaml >= 5.1
 sqlalchemy
+psycopg2
 testing.postgresql
+
 lsst-dax-apdb @ git+https://github.com/lsst/dax_apdb@main
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-resources[s3] @ git+https://github.com/lsst/resources@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pydantic >=2,<3
 pyyaml >= 5.1
 sqlalchemy
 psycopg2
+cloud-sql-python-connector[pg8000]
 testing.postgresql
 
 lsst-dax-apdb @ git+https://github.com/lsst/dax_apdb@main

--- a/tests/test_ppdb_bigquery.py
+++ b/tests/test_ppdb_bigquery.py
@@ -19,8 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 import uuid
+from unittest import mock
 
 import astropy.time
 import sqlalchemy
@@ -28,6 +30,7 @@ import sqlalchemy
 from lsst.dax.ppdb import Ppdb
 from lsst.dax.ppdb.bigquery import ChunkStatus, PpdbBigQuery, PpdbReplicaChunkExtended
 from lsst.dax.ppdb.bigquery.ppdb_bigquery import UpdatableField
+from lsst.dax.ppdb.sql import PasswordProvider, PpdbSqlBaseConfig
 from lsst.dax.ppdb.tests import PpdbTest
 from lsst.dax.ppdb.tests._bigquery import PostgresMixin, SqliteMixin
 
@@ -326,3 +329,107 @@ class PpdbBigQueryTestCase(SqliteMixin, unittest.TestCase):
 
         result = ppdb.get_promotable_chunks()
         self.assertEqual(len(result), 0)
+
+
+class _StubPasswordProvider(PasswordProvider):
+    """Password provider returning a fixed password for tests.
+
+    Parameters
+    ----------
+    password
+        Password to return from `get_password`.
+    """
+
+    def __init__(self, password: str = "secret") -> None:
+        self._password = password
+
+    def get_password(self) -> str:
+        return self._password
+
+
+class MakeEngineConnectorTestCase(unittest.TestCase):
+    """Tests for Cloud SQL Connector engine creation in `PpdbBigQuery`."""
+
+    # Minimal environment required by the Cloud SQL Connector engine.
+    CONNECTOR_ENV = {
+        "CLOUDSQL_ENABLED": "true",
+        "CLOUDSQL_INSTANCE_CONNECTION_NAME": "my-project:us-central1:my-instance",
+        "CLOUDSQL_USER": "db-user",
+        "CLOUDSQL_DB_NAME": "db-name",
+    }
+
+    def setUp(self) -> None:
+        self.config = PpdbSqlBaseConfig(db_url="sqlite:///:memory:")
+        # Patch the module-level Connector so the tests do not depend on a real
+        # GCP connection being available.
+        self.connector = mock.MagicMock(name="connector_instance")
+        self.connector_cls = mock.MagicMock(name="Connector", return_value=self.connector)
+        connector_patcher = mock.patch("lsst.dax.ppdb.bigquery.ppdb_bigquery.Connector", self.connector_cls)
+        connector_patcher.start()
+        self.addCleanup(connector_patcher.stop)
+
+    def _make_engine(self, **kwargs: object) -> mock.MagicMock:
+        """Call ``make_engine`` for the connector path with a patched
+        ``create_engine`` and return the ``create_engine`` mock.
+        """
+        with mock.patch("sqlalchemy.create_engine") as create_engine:
+            PpdbBigQuery.make_engine(self.config, **kwargs)
+        return create_engine
+
+    def test_connector_engine(self) -> None:
+        """The connector engine is built from the environment using IAM
+        auth.
+        """
+        with mock.patch.dict(os.environ, self.CONNECTOR_ENV, clear=True):
+            create_engine = self._make_engine()
+
+        self.connector_cls.assert_called_once_with(refresh_strategy="lazy")
+        self.assertEqual(create_engine.call_args.args[0], "postgresql+pg8000://")
+        create_engine.call_args.kwargs["creator"]()
+        self.connector.connect.assert_called_once_with(
+            "my-project:us-central1:my-instance",
+            "pg8000",
+            user="db-user",
+            db="db-name",
+            ip_type="private",
+            enable_iam_auth=True,
+        )
+
+    def test_password_auth(self) -> None:
+        """A password provider switches from IAM to password authentication."""
+        with mock.patch.dict(os.environ, self.CONNECTOR_ENV, clear=True):
+            create_engine = self._make_engine(password_provider=_StubPasswordProvider("hunter2"))
+
+        create_engine.call_args.kwargs["creator"]()
+        self.connector.connect.assert_called_once_with(
+            "my-project:us-central1:my-instance",
+            "pg8000",
+            user="db-user",
+            db="db-name",
+            ip_type="private",
+            password="hunter2",
+            enable_iam_auth=False,
+        )
+
+    def test_invalid_environment_raises(self) -> None:
+        """A missing required variable or an invalid IP type raises
+        ``OSError``.
+        """
+        missing = dict(self.CONNECTOR_ENV)
+        del missing["CLOUDSQL_INSTANCE_CONNECTION_NAME"]
+        bad_ip = dict(self.CONNECTOR_ENV, CLOUDSQL_IP_TYPE="bogus")
+        for env in (missing, bad_ip):
+            with mock.patch.dict(os.environ, env, clear=True):
+                with self.assertRaises(OSError):
+                    self._make_engine()
+
+    def test_cloudsql_enabled_dispatch(self) -> None:
+        """``make_engine`` uses the connector only when
+        ``CLOUDSQL_ENABLED``.
+        """
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(PpdbBigQuery.is_cloudsql_enabled())
+            engine = PpdbBigQuery.make_engine(self.config)
+            self.assertEqual(engine.dialect.name, "sqlite")
+        with mock.patch.dict(os.environ, {"CLOUDSQL_ENABLED": "true"}, clear=True):
+            self.assertTrue(PpdbBigQuery.is_cloudsql_enabled())


### PR DESCRIPTION
This adds support for Cloud SQL through an alternate configuration path using environment variables, overriding the SQL connection information from the config. I also added some Postgres requirements which were missing.

I've left password provider functionality in for now, which allows reading a secret from the cloud secrets manager, even though we don't need it anymore. I'll remove it on another, separate cleanup ticket.